### PR TITLE
Implement clean command deletion

### DIFF
--- a/handlers/cleancommands.py
+++ b/handlers/cleancommands.py
@@ -1,5 +1,46 @@
 from pyrogram import Client, filters
+from utils.decorators import admin_required
+from utils.db import get_chat_setting, set_chat_setting
+import asyncio
 
-@Client.on_message(filters.command('cleancommands'))
-async def placeholder(_, m):
-    await m.reply('CleanCommands module not implemented yet.')
+
+@Client.on_message(filters.command('cleancommand') & filters.group)
+@admin_required
+async def set_clean(client, message):
+    if len(message.command) < 2:
+        await message.reply('Usage: /cleancommand <seconds|off>')
+        return
+    arg = message.command[1].lower()
+    if arg in {'off', '0'}:
+        set_chat_setting(message.chat.id, 'clean_delay', '0')
+        await message.reply('Command cleaning disabled.')
+    else:
+        try:
+            delay = int(arg)
+        except ValueError:
+            await message.reply('Provide a number of seconds or "off".')
+            return
+        set_chat_setting(message.chat.id, 'clean_delay', str(delay))
+        await message.reply(f'Commands will be deleted after {delay} seconds.')
+
+
+@Client.on_message(filters.command('keepcommand') & filters.group)
+@admin_required
+async def disable_clean(client, message):
+    set_chat_setting(message.chat.id, 'clean_delay', '0')
+    await message.reply('Command cleaning disabled.')
+
+
+@Client.on_message(filters.command & (filters.group | filters.private), group=-1)
+async def auto_clean(client, message):
+    delay = get_chat_setting(message.chat.id, 'clean_delay', '0')
+    try:
+        delay_int = int(delay)
+    except (TypeError, ValueError):
+        return
+    if delay_int > 0:
+        await asyncio.sleep(delay_int)
+        try:
+            await message.delete()
+        except Exception:
+            pass

--- a/utils/db.py
+++ b/utils/db.py
@@ -27,3 +27,21 @@ with closing(conn.cursor()) as cur:
 
 def get_conn():
     return conn
+
+def set_chat_setting(chat_id: int, key: str, value: str) -> None:
+    with closing(conn.cursor()) as cur:
+        cur.execute(
+            'REPLACE INTO settings (chat_id, key, value) VALUES (?,?,?)',
+            (chat_id, key, value),
+        )
+        conn.commit()
+
+
+def get_chat_setting(chat_id: int, key: str, default=None):
+    with closing(conn.cursor()) as cur:
+        cur.execute(
+            'SELECT value FROM settings WHERE chat_id=? AND key=?',
+            (chat_id, key),
+        )
+        row = cur.fetchone()
+    return row[0] if row else default


### PR DESCRIPTION
## Summary
- implement chat settings helpers
- add clean commands handler to delete command messages after a delay

## Testing
- `python -m py_compile main.py handlers/*.py utils/*.py`
- `pip install pyrogram tgcrypto --quiet`

------
https://chatgpt.com/codex/tasks/task_b_687c1a0eccc48329b773e911826f3765