### PR TITLE
Fix plugin registration and cleancommands filter

### DIFF
--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -13,3 +13,11 @@ def register_all(app):
         module = importlib.import_module(f'handlers.{module_name}')
         if hasattr(module, 'register'):
             module.register(app)
+        # Support modules that use the ``@Client.on_*`` decorators without
+        # providing an explicit ``register`` function. Those decorators attach
+        # handler information to the decorated callables via a ``handlers``
+        # attribute which we can use to register them here.
+        for attr in module.__dict__.values():
+            if callable(attr) and hasattr(attr, "handlers"):
+                for handler, group in getattr(attr, "handlers"):
+                    app.add_handler(handler, group)

--- a/handlers/cleancommands.py
+++ b/handlers/cleancommands.py
@@ -31,7 +31,10 @@ async def disable_clean(client, message):
     await message.reply('Command cleaning disabled.')
 
 
-@Client.on_message(filters.command & (filters.group | filters.private), group=-1)
+# Apply to all messages starting with a command prefix so they can be removed
+# after a delay. ``filters.command`` requires specifying commands explicitly,
+# so we use a regex filter matching the leading '/' instead.
+@Client.on_message(filters.regex(r'^/') & (filters.group | filters.private), group=-1)
 async def auto_clean(client, message):
     delay = get_chat_setting(message.chat.id, 'clean_delay', '0')
     try:


### PR DESCRIPTION
## Summary
- support automatic registration of decorator-style handlers
- fix command auto-cleaning filter to catch all commands

## Testing
- `python3 main.py` *(fails: Unable to connect due to network issues)*

------
https://chatgpt.com/codex/tasks/task_b_687c1e8bc6ec8329ad38522acbf42744