### PR TITLE
Add moderation command implementations

### DIFF
--- a/buttons/notes.py
+++ b/buttons/notes.py
@@ -1,0 +1,8 @@
+from pyrogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+
+
+def notes_panel():
+    return InlineKeyboardMarkup([
+        [InlineKeyboardButton('Example usage', callback_data='notes:example'), InlineKeyboardButton('Formatting', callback_data='notes:format')],
+        [InlineKeyboardButton('Back', callback_data='main:menu')]
+    ])

--- a/handlers/locks.py
+++ b/handlers/locks.py
@@ -1,5 +1,45 @@
-from pyrogram import Client, filters
+from pyrogram import Client, filters, types
+from utils.decorators import admin_required
 
-@Client.on_message(filters.command('locks'))
-async def placeholder(_, m):
-    await m.reply('Locks module not implemented yet.')
+LOCK_MAP = {
+    'sticker': 'can_send_stickers',
+    'media': 'can_send_media_messages',
+    'photo': 'can_send_photos',
+    'video': 'can_send_videos',
+}
+
+
+@Client.on_message(filters.command('lock') & filters.group)
+@admin_required
+async def lock_cmd(client, message):
+    if len(message.command) < 2:
+        await message.reply('Usage: /lock <type>')
+        return
+    lock_type = message.command[1].lower()
+    perm = LOCK_MAP.get(lock_type)
+    if not perm:
+        await message.reply('Unknown lock type.')
+        return
+    perms = types.ChatPermissions(**{perm: False})
+    await client.set_chat_permissions(message.chat.id, perms)
+    await message.reply(f'Locked {lock_type}.')
+
+
+@Client.on_message(filters.command('unlock') & filters.group)
+@admin_required
+async def unlock_cmd(client, message):
+    if len(message.command) < 2:
+        await message.reply('Usage: /unlock <type>')
+        return
+    lock_type = message.command[1].lower()
+    perm = LOCK_MAP.get(lock_type)
+    if not perm:
+        await message.reply('Unknown lock type.')
+        return
+    perms = types.ChatPermissions(**{perm: True})
+    await client.set_chat_permissions(message.chat.id, perms)
+    await message.reply(f'Unlocked {lock_type}.')
+
+
+def register(app: Client):
+    pass

--- a/handlers/misc.py
+++ b/handlers/misc.py
@@ -43,8 +43,55 @@ async def menu_cb(client, query):
     await query.answer()
 
 
+RUN_STRINGS = [
+    "Eeny meeny miny moe...",
+    "Time to run away!",
+    "Let's hide!",
+    "Runs to the hills!",
+]
+
+async def runs(client, message):
+    await message.reply(random.choice(RUN_STRINGS))
+
+async def get_id(client, message):
+    target = message.reply_to_message.from_user if message.reply_to_message else message.from_user
+    if message.command and len(message.command) > 1:
+        username = message.command[1].lstrip('@')
+        try:
+            target = await client.get_users(username)
+        except Exception:
+            pass
+    await message.reply(f'`{target.id}`')
+
+async def info(client, message):
+    user = message.reply_to_message.from_user if message.reply_to_message else message.from_user
+    text = f"**{user.first_name}**\nID: `{user.id}`"
+    if user.username:
+        text += f"\n@{user.username}"
+    if user.bio:
+        text += f"\n{user.bio}"
+    await message.reply(text)
+
+async def donate(client, message):
+    await message.reply("[Donate here](https://example.com/donate)", disable_web_page_preview=True)
+
+async def markdown_help(client, message):
+    if message.chat.type != 'private':
+        await message.reply('I\'ve messaged you the Markdown guide!')
+    await client.send_message(message.from_user.id, '**Markdown Guide**\nUse `*bold*`, `_italic_`, `[text](url)`')
+
+async def limits(client, message):
+    await message.reply('No limits are currently enforced.')
+
+
 def register(app):
     app.add_handler(MessageHandler(start, filters.command('start')))
     app.add_handler(MessageHandler(menu, filters.command('menu')))
+    app.add_handler(MessageHandler(runs, filters.command('runs')))
+    app.add_handler(MessageHandler(get_id, filters.command('id')))
+    app.add_handler(MessageHandler(info, filters.command('info')))
+    app.add_handler(MessageHandler(donate, filters.command('donate')))
+    app.add_handler(MessageHandler(markdown_help, filters.command('markdownhelp')))
+    app.add_handler(MessageHandler(limits, filters.command('limits')))
     app.add_handler(CallbackQueryHandler(panel_open, filters.regex('^[a-z]+:open$')))
     app.add_handler(CallbackQueryHandler(menu_cb, filters.regex('^main:menu$')))

--- a/handlers/notes.py
+++ b/handlers/notes.py
@@ -1,36 +1,122 @@
 from pyrogram import Client, filters
+from pyrogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+
 from utils.decorators import admin_required
-from utils.db import get_conn
+from utils.db import get_conn, set_chat_setting, get_chat_setting
+from buttons.notes import notes_panel
 
 conn = get_conn()
 
+
+def _get_note(chat_id: int, name: str):
+    cur = conn.cursor()
+    cur.execute('SELECT content FROM notes WHERE chat_id=? AND name=?', (chat_id, name.lower()))
+    row = cur.fetchone()
+    return row[0] if row else None
+
+
 @Client.on_message(filters.command('save') & filters.group)
 @admin_required
-async def save(client, message):
-    if len(message.command) < 2 or not message.reply_to_message:
-        await message.reply('Usage: /save note_name (reply to message)')
+async def save_note(client, message):
+    if len(message.command) < 2:
+        await message.reply('Usage: /save <name> (reply or text)')
         return
-    name = message.command[1]
-    content = message.reply_to_message.text or message.reply_to_message.caption
-    if not content:
-        await message.reply('No text to save.')
-        return
+    name = message.command[1].lower()
+    if message.reply_to_message:
+        content = message.reply_to_message.text or message.reply_to_message.caption
+    else:
+        if len(message.command) < 3:
+            await message.reply('Provide note content.')
+            return
+        content = ' '.join(message.command[2:])
     cur = conn.cursor()
-    cur.execute('DELETE FROM notes WHERE chat_id=? AND name=?', (message.chat.id, name))
-    cur.execute('INSERT INTO notes(chat_id, name, content) VALUES(?,?,?)', (message.chat.id, name, content))
+    cur.execute('REPLACE INTO notes(chat_id, name, content) VALUES(?,?,?)', (message.chat.id, name, content))
     conn.commit()
     await message.reply('Saved note.')
 
-@Client.on_message(filters.command('get') & filters.group)
-async def get_note(client, message):
+
+@Client.on_message(filters.command('clear') & filters.group)
+@admin_required
+async def clear_note(client, message):
     if len(message.command) < 2:
-        await message.reply('Usage: /get note_name')
+        await message.reply('Usage: /clear <name>')
         return
-    name = message.command[1]
+    name = message.command[1].lower()
     cur = conn.cursor()
-    cur.execute('SELECT content FROM notes WHERE chat_id=? AND name=?', (message.chat.id, name))
-    row = cur.fetchone()
-    if row:
-        await message.reply(row[0])
+    cur.execute('DELETE FROM notes WHERE chat_id=? AND name=?', (message.chat.id, name))
+    conn.commit()
+    await message.reply('Note deleted.')
+
+
+@Client.on_message(filters.command(['notes', 'saved']) & filters.group)
+async def list_notes(client, message):
+    cur = conn.cursor()
+    cur.execute('SELECT name FROM notes WHERE chat_id=? ORDER BY name', (message.chat.id,))
+    rows = cur.fetchall()
+    if not rows:
+        await message.reply('No notes in this chat.')
+    else:
+        text = '**Notes:**\n' + '\n'.join(f'- {n[0]}' for n in rows)
+        await message.reply(text, reply_markup=notes_panel())
+
+
+@Client.on_message(filters.command('clearall') & filters.group)
+@admin_required
+async def clear_all_notes(client, message):
+    cur = conn.cursor()
+    cur.execute('DELETE FROM notes WHERE chat_id=?', (message.chat.id,))
+    conn.commit()
+    await message.reply('All notes cleared.')
+
+
+@Client.on_message(filters.command('privatenotes') & filters.group)
+@admin_required
+async def private_notes_toggle(client, message):
+    current = get_chat_setting(message.chat.id, 'privatenotes', 'off')
+    new = 'off' if current == 'on' else 'on'
+    set_chat_setting(message.chat.id, 'privatenotes', new)
+    await message.reply(f'Private notes are now {new}.')
+
+
+@Client.on_message(filters.command('get') & filters.group)
+async def get_note_cmd(client, message):
+    if len(message.command) < 2:
+        await message.reply('Usage: /get <name>')
+        return
+    name = message.command[1].lower()
+    content = _get_note(message.chat.id, name)
+    if content:
+        if get_chat_setting(message.chat.id, 'privatenotes', 'off') == 'on':
+            await client.send_message(message.from_user.id, content)
+            await message.reply('Sent you the note in PM.')
+        else:
+            await message.reply(content)
     else:
         await message.reply('Note not found.')
+
+
+@Client.on_message(filters.text & filters.group)
+async def get_note_hash(client, message):
+    if not message.text or not message.text.startswith('#'):
+        return
+    name = message.text[1:].split()[0].lower()
+    content = _get_note(message.chat.id, name)
+    if content:
+        if get_chat_setting(message.chat.id, 'privatenotes', 'off') == 'on':
+            await client.send_message(message.from_user.id, content)
+        else:
+            await message.reply(content)
+
+
+@Client.on_callback_query(filters.regex('^notes:'))
+async def notes_cb(client, query):
+    data = query.data.split(':')[1]
+    if data == 'example':
+        await query.message.edit('Use `/save name` in reply to a message to save it.', reply_markup=notes_panel())
+    elif data == 'format':
+        await query.message.edit('Markdown and buttons are supported.', reply_markup=notes_panel())
+    await query.answer()
+
+
+def register(app: Client):
+    pass

--- a/handlers/pin.py
+++ b/handlers/pin.py
@@ -1,5 +1,83 @@
 from pyrogram import Client, filters
+from utils.decorators import admin_required
+from utils.db import set_chat_setting, get_chat_setting
 
-@Client.on_message(filters.command('pin'))
-async def placeholder(_, m):
-    await m.reply('Pin module not implemented yet.')
+
+@Client.on_message(filters.command('pinned') & filters.group)
+async def pinned_cmd(client, message):
+    chat = await client.get_chat(message.chat.id)
+    if not chat.pinned_message:
+        await message.reply('No pinned message.')
+    else:
+        await message.reply(chat.pinned_message.text or 'Pinned message.')
+
+
+@Client.on_message(filters.command('pin') & filters.group)
+@admin_required
+async def pin_cmd(client, message):
+    if not message.reply_to_message:
+        await message.reply('Reply to a message to pin.')
+        return
+    loud = False
+    if len(message.command) > 1 and message.command[1].lower() in {'loud', 'notify'}:
+        loud = True
+    await message.reply_to_message.pin(disable_notification=not loud)
+
+
+@Client.on_message(filters.command('permapin') & filters.group)
+@admin_required
+async def permapin_cmd(client, message):
+    if len(message.command) < 2:
+        await message.reply('Usage: /permapin <text>')
+        return
+    sent = await message.reply(' '.join(message.command[1:]))
+    await sent.pin()
+
+
+@Client.on_message(filters.command('unpin') & filters.group)
+@admin_required
+async def unpin_cmd(client, message):
+    if message.reply_to_message:
+        await message.reply_to_message.unpin()
+    else:
+        await client.unpin_chat_message(message.chat.id)
+
+
+@Client.on_message(filters.command('unpinall') & filters.group)
+@admin_required
+async def unpin_all_cmd(client, message):
+    await client.unpin_all_chat_messages(message.chat.id)
+
+
+@Client.on_message(filters.command('antichannelpin') & filters.group)
+@admin_required
+async def antichannelpin_cmd(client, message):
+    if len(message.command) == 1:
+        state = get_chat_setting(message.chat.id, 'antichannelpin', 'off')
+        await message.reply(f'Anti-channel pin is {state}.')
+        return
+    value = message.command[1].lower()
+    if value not in {'on', 'off'}:
+        await message.reply('Usage: /antichannelpin <on/off>')
+        return
+    set_chat_setting(message.chat.id, 'antichannelpin', value)
+    await message.reply(f'Anti-channel pin set to {value}.')
+
+
+@Client.on_message(filters.command('cleanlinked') & filters.group)
+@admin_required
+async def cleanlinked_cmd(client, message):
+    if len(message.command) == 1:
+        state = get_chat_setting(message.chat.id, 'cleanlinked', 'off')
+        await message.reply(f'Clean linked messages is {state}.')
+        return
+    value = message.command[1].lower()
+    if value not in {'on', 'off'}:
+        await message.reply('Usage: /cleanlinked <on/off>')
+        return
+    set_chat_setting(message.chat.id, 'cleanlinked', value)
+    await message.reply(f'Clean linked messages set to {value}.')
+
+
+def register(app: Client):
+    pass

--- a/handlers/privacy.py
+++ b/handlers/privacy.py
@@ -1,5 +1,15 @@
 from pyrogram import Client, filters
 
+
 @Client.on_message(filters.command('privacy'))
-async def placeholder(_, m):
-    await m.reply('Privacy module not implemented yet.')
+async def privacy_cmd(client, message):
+    text = 'We only store data necessary for moderation. Use /delmydata to remove your info.'
+    if message.chat.type != 'private':
+        await message.reply('Check your PM for privacy info.')
+        await client.send_message(message.from_user.id, text)
+    else:
+        await message.reply(text)
+
+
+def register(app: Client):
+    pass

--- a/handlers/purge.py
+++ b/handlers/purge.py
@@ -1,5 +1,66 @@
 from pyrogram import Client, filters
+from utils.decorators import admin_required
 
-@Client.on_message(filters.command('purge'))
-async def placeholder(_, m):
-    await m.reply('Purge module not implemented yet.')
+purge_points = {}
+
+
+@Client.on_message(filters.command('purge') & filters.group)
+@admin_required
+async def purge_cmd(client, message):
+    if not message.reply_to_message:
+        await message.reply('Reply to a message to start purging.')
+        return
+    limit = None
+    if len(message.command) > 1 and message.command[1].isdigit():
+        limit = int(message.command[1])
+    ids = []
+    start_id = message.reply_to_message.id
+    if limit:
+        ids = list(range(start_id, start_id + limit + 1))
+    else:
+        ids = list(range(start_id, message.id + 1))
+    await client.delete_messages(message.chat.id, ids)
+    await message.reply(f'Deleted {len(ids)} messages.', quote=False)
+
+
+@Client.on_message(filters.command('spurge') & filters.group)
+@admin_required
+async def spurge_cmd(client, message):
+    if not message.reply_to_message:
+        return
+    ids = list(range(message.reply_to_message.id, message.id + 1))
+    await client.delete_messages(message.chat.id, ids)
+
+
+@Client.on_message(filters.command('del') & filters.group)
+@admin_required
+async def del_cmd(client, message):
+    if message.reply_to_message:
+        await client.delete_messages(message.chat.id, [message.reply_to_message.id, message.id])
+
+
+@Client.on_message(filters.command('purgefrom') & filters.group)
+@admin_required
+async def purge_from_cmd(client, message):
+    if not message.reply_to_message:
+        await message.reply('Reply to a message to set purge point.')
+        return
+    purge_points[message.chat.id] = message.reply_to_message.id
+    await message.reply('Purge from point saved.')
+
+
+@Client.on_message(filters.command('purgeto') & filters.group)
+@admin_required
+async def purge_to_cmd(client, message):
+    start = purge_points.get(message.chat.id)
+    if not start:
+        await message.reply('No purgefrom point set.')
+        return
+    ids = list(range(start, message.id + 1))
+    await client.delete_messages(message.chat.id, ids)
+    purge_points.pop(message.chat.id, None)
+    await message.reply(f'Deleted {len(ids)} messages.', quote=False)
+
+
+def register(app: Client):
+    pass

--- a/handlers/rules.py
+++ b/handlers/rules.py
@@ -1,5 +1,73 @@
 from pyrogram import Client, filters
+from utils.decorators import admin_required
+from utils.db import set_chat_setting, get_chat_setting
+from pyrogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 
-@Client.on_message(filters.command('rules'))
-async def placeholder(_, m):
-    await m.reply('Rules module not implemented yet.')
+
+@Client.on_message(filters.command('rules') & (filters.group | filters.private))
+async def rules_cmd(client, message):
+    rules = get_chat_setting(message.chat.id if message.chat.type != 'private' else message.from_user.id, 'rules_text', 'No rules set.')
+    button = get_chat_setting(message.chat.id if message.chat.type != 'private' else message.from_user.id, 'rules_button')
+    if get_chat_setting(message.chat.id if message.chat.type != 'private' else message.from_user.id, 'privaterules', 'off') == 'on' and message.chat.type != 'private':
+        await client.send_message(message.from_user.id, rules)
+        await message.reply('Rules sent in PM.')
+        return
+    markup = None
+    if button:
+        markup = InlineKeyboardMarkup([[InlineKeyboardButton(button, callback_data='rules:back')]])
+    await message.reply(rules, reply_markup=markup, disable_web_page_preview=True)
+
+
+@Client.on_message(filters.command('setrules') & filters.group)
+@admin_required
+async def setrules_cmd(client, message):
+    if len(message.command) < 2 and not message.reply_to_message:
+        await message.reply('Usage: /setrules <text> or reply')
+        return
+    text = message.reply_to_message.text if message.reply_to_message else ' '.join(message.command[1:])
+    set_chat_setting(message.chat.id, 'rules_text', text)
+    await message.reply('Rules updated.')
+
+
+@Client.on_message(filters.command('privaterules') & filters.group)
+@admin_required
+async def private_rules_cmd(client, message):
+    current = get_chat_setting(message.chat.id, 'privaterules', 'off')
+    new = 'off' if current == 'on' else 'on'
+    set_chat_setting(message.chat.id, 'privaterules', new)
+    await message.reply(f'Private rules toggled to {new}.')
+
+
+@Client.on_message(filters.command('resetrules') & filters.group)
+@admin_required
+async def reset_rules_cmd(client, message):
+    set_chat_setting(message.chat.id, 'rules_text', None)
+    await message.reply('Rules cleared.')
+
+
+@Client.on_message(filters.command('setrulesbutton') & filters.group)
+@admin_required
+async def set_rules_button(client, message):
+    if len(message.command) < 2:
+        await message.reply('Usage: /setrulesbutton <name>')
+        return
+    set_chat_setting(message.chat.id, 'rules_button', ' '.join(message.command[1:]))
+    await message.reply('Rules button updated.')
+
+
+@Client.on_message(filters.command('resetrulesbutton') & filters.group)
+@admin_required
+async def reset_rules_button(client, message):
+    set_chat_setting(message.chat.id, 'rules_button', None)
+    await message.reply('Rules button reset.')
+
+
+@Client.on_callback_query(filters.regex('^rules:back'))
+async def rules_back(client, query):
+    rules = get_chat_setting(query.message.chat.id, 'rules_text', 'No rules set.')
+    await query.message.edit(rules)
+    await query.answer()
+
+
+def register(app: Client):
+    pass

--- a/handlers/topics.py
+++ b/handlers/topics.py
@@ -1,5 +1,87 @@
 from pyrogram import Client, filters
+from utils.decorators import admin_required
+from utils.db import set_chat_setting, get_chat_setting
 
-@Client.on_message(filters.command('topics'))
-async def placeholder(_, m):
-    await m.reply('Topics module not implemented yet.')
+
+@Client.on_message(filters.command('actiontopic') & filters.group)
+async def action_topic(client, message):
+    topic = get_chat_setting(message.chat.id, 'action_topic')
+    if topic:
+        await message.reply(f'Current action topic: {topic}')
+    else:
+        await message.reply('No action topic set.')
+
+
+@Client.on_message(filters.command('setactiontopic') & filters.group)
+@admin_required
+async def set_action_topic(client, message):
+    if message.reply_to_message:
+        topic_id = message.reply_to_message.id
+    elif len(message.command) > 1 and message.command[1].isdigit():
+        topic_id = int(message.command[1])
+    else:
+        await message.reply('Reply to a topic message or give topic id.')
+        return
+    set_chat_setting(message.chat.id, 'action_topic', str(topic_id))
+    await message.reply('Action topic updated.')
+
+
+@Client.on_message(filters.command('newtopic') & filters.group)
+@admin_required
+async def new_topic(client, message):
+    if len(message.command) < 2:
+        await message.reply('Usage: /newtopic <name>')
+        return
+    topic = await client.create_forum_topic(message.chat.id, message.command[1])
+    await message.reply(f'Topic created with id {topic.message_thread_id}.')
+
+
+@Client.on_message(filters.command('renametopic') & filters.group)
+@admin_required
+async def rename_topic(client, message):
+    if len(message.command) < 2:
+        await message.reply('Usage: /renametopic <name>')
+        return
+    topic_id = message.reply_to_message.message_thread_id if message.reply_to_message else message.message_thread_id
+    if not topic_id:
+        await message.reply('Use this in a topic or reply to topic.')
+        return
+    await client.edit_forum_topic(message.chat.id, topic_id, name=' '.join(message.command[1:]))
+    await message.reply('Topic renamed.')
+
+
+@Client.on_message(filters.command('closetopic') & filters.group)
+@admin_required
+async def close_topic(client, message):
+    topic_id = message.reply_to_message.message_thread_id if message.reply_to_message else message.message_thread_id
+    if not topic_id:
+        await message.reply('Use this in a topic or reply to topic.')
+        return
+    await client.close_forum_topic(message.chat.id, topic_id)
+    await message.reply('Topic closed.')
+
+
+@Client.on_message(filters.command('reopentopic') & filters.group)
+@admin_required
+async def reopen_topic(client, message):
+    topic_id = message.reply_to_message.message_thread_id if message.reply_to_message else message.message_thread_id
+    if not topic_id:
+        await message.reply('Use this in a topic or reply to topic.')
+        return
+    await client.reopen_forum_topic(message.chat.id, topic_id)
+    await message.reply('Topic reopened.')
+
+
+@Client.on_message(filters.command('deletetopic') & filters.group)
+@admin_required
+async def delete_topic(client, message):
+    topic_id = message.reply_to_message.message_thread_id if message.reply_to_message else message.message_thread_id
+    if not topic_id:
+        await message.reply('Use this in a topic or reply to topic.')
+        return
+    await client.delete_forum_topic(message.chat.id, topic_id)
+    await message.reply('Topic deleted.')
+
+
+def register(app: Client):
+    pass


### PR DESCRIPTION
## Summary
- implement miscellaneous commands like `/runs`, `/id`, `/info`, `/donate`, `/markdownhelp`, `/limits`
- expand notes functionality with saving, getting, deleting and PM options
- implement purge commands for quick message cleanup
- add pin management commands
- introduce rules, topics, privacy and lock modules
- extend warnings module with more commands
- add small inline buttons for notes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_687c20e6c060832994f98023ec6776da