### PR TITLE
Add broadcast tracking and settings module

### DIFF
--- a/db/broadcast.py
+++ b/db/broadcast.py
@@ -1,0 +1,37 @@
+import aiosqlite
+
+DB_PATH = "bot.db"
+
+async def add_user(user_id: int) -> None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "INSERT OR IGNORE INTO broadcast_users(user_id) VALUES(?)",
+            (user_id,),
+        )
+        await db.commit()
+
+async def add_group(group_id: int) -> None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "INSERT OR IGNORE INTO broadcast_groups(group_id) VALUES(?)",
+            (group_id,),
+        )
+        await db.commit()
+
+async def remove_group(group_id: int) -> None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "DELETE FROM broadcast_groups WHERE group_id=?",
+            (group_id,),
+        )
+        await db.commit()
+
+async def get_broadcast_users() -> list[int]:
+    async with aiosqlite.connect(DB_PATH) as db:
+        rows = await db.execute_fetchall("SELECT user_id FROM broadcast_users")
+        return [r[0] for r in rows]
+
+async def get_broadcast_groups() -> list[int]:
+    async with aiosqlite.connect(DB_PATH) as db:
+        rows = await db.execute_fetchall("SELECT group_id FROM broadcast_groups")
+        return [r[0] for r in rows]

--- a/db/settings.py
+++ b/db/settings.py
@@ -1,0 +1,25 @@
+import aiosqlite
+
+DB_PATH = "bot.db"
+
+async def set_chat_setting(chat_id: int, key: str, value: str | None) -> None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        if value is None:
+            await db.execute(
+                "DELETE FROM settings WHERE chat_id=? AND key=?",
+                (chat_id, key),
+            )
+        else:
+            await db.execute(
+                "REPLACE INTO settings (chat_id, key, value) VALUES (?, ?, ?)",
+                (chat_id, key, value),
+            )
+        await db.commit()
+
+async def get_chat_setting(chat_id: int, key: str, default=None):
+    async with aiosqlite.connect(DB_PATH) as db:
+        row = await db.execute_fetchone(
+            "SELECT value FROM settings WHERE chat_id=? AND key=?",
+            (chat_id, key),
+        )
+        return row[0] if row else default

--- a/handlers/broadcast.py
+++ b/handlers/broadcast.py
@@ -9,7 +9,7 @@ from pyrogram.errors import (
 )
 
 from config import OWNER_ID
-from utils.db import get_broadcast_groups, get_broadcast_users
+from db.broadcast import get_broadcast_groups, get_broadcast_users
 from utils.errors import catch_errors
 
 logger = logging.getLogger(__name__)

--- a/handlers/group.py
+++ b/handlers/group.py
@@ -3,6 +3,7 @@ from pyrogram import Client, filters
 from pyrogram.types import Message
 from config import LOG_GROUP_ID
 from utils.errors import catch_errors
+from db.broadcast import add_user, add_group, remove_group
 
 logger = logging.getLogger(__name__)
 
@@ -12,6 +13,15 @@ def register(app: Client) -> None:
     @catch_errors
     async def start_in_private(client: Client, message: Message):
         logger.info("📥 /start by user %s in PM", message.from_user.id)
+        await add_user(message.from_user.id)
+        if LOG_GROUP_ID:
+            try:
+                await client.send_message(
+                    LOG_GROUP_ID,
+                    f"📥 User {message.from_user.id} started me in PM",
+                )
+            except Exception as e:
+                logger.warning("Failed to send log to LOG_GROUP_ID: %s", e)
 
     # ✅ Bot added to a group
     @app.on_message(filters.new_chat_members & filters.group)
@@ -20,6 +30,7 @@ def register(app: Client) -> None:
         me = await client.get_me()
         if any(member.id == me.id for member in message.new_chat_members):
             logger.info("➕ Bot added to group %s", message.chat.id)
+            await add_group(message.chat.id)
             if LOG_GROUP_ID:
                 try:
                     await client.send_message(LOG_GROUP_ID, f"➕ Bot added to group {message.chat.id}")
@@ -33,6 +44,7 @@ def register(app: Client) -> None:
         me = await client.get_me()
         if message.left_chat_member and message.left_chat_member.id == me.id:
             logger.info("➖ Bot removed from group %s", message.chat.id)
+            await remove_group(message.chat.id)
             if LOG_GROUP_ID:
                 try:
                     await client.send_message(LOG_GROUP_ID, f"➖ Bot removed from group {message.chat.id}")

--- a/main.py
+++ b/main.py
@@ -1,10 +1,12 @@
 """Main entry point for the Telegram bot."""
 
+import asyncio
 import logging
 import os
 from pyrogram import Client
 
 from handlers import register_all
+from db import init_db
 
 
 logging.basicConfig(
@@ -27,10 +29,12 @@ def main() -> None:
     """Load handlers and start the bot."""
 
     try:
+        LOGGER.info("Initialising database ...")
+        asyncio.run(init_db())
         LOGGER.info("Loading handlers ...")
         register_all(app)
     except Exception:
-        LOGGER.exception("Failed to load handlers")
+        LOGGER.exception("Failed to initialise bot")
         return
 
     LOGGER.info("Starting bot ...")


### PR DESCRIPTION
## Summary
- introduce `db.settings` with async helpers
- implement DB helpers for broadcast user/group tracking
- log and track groups/users in `handlers/group`
- update broadcast module imports
- init database at startup

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_687c7819dfb483299003459900cc4fa6