### PR TITLE
Enhance control panel callbacks

### DIFF
--- a/buttons/__init__.py
+++ b/buttons/__init__.py
@@ -13,3 +13,11 @@ def back_button(callback: str) -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup([
         [InlineKeyboardButton("Back ⬅️", callback_data=callback)]
     ])
+
+from .admin import admin_panel
+from .notes import notes_panel
+from .filters import filters_panel
+from .rules import rules_panel
+from .warnings import warnings_panel
+from .approvals import approvals_panel
+from .lock import lock_panel

--- a/buttons/approvals.py
+++ b/buttons/approvals.py
@@ -1,0 +1,13 @@
+from pyrogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+
+
+def approvals_panel() -> InlineKeyboardMarkup:
+    """Markup for the Approvals module."""
+    return InlineKeyboardMarkup([
+        [
+            InlineKeyboardButton("✅ Approve", callback_data="approvals:approve"),
+            InlineKeyboardButton("🚫 Unapprove", callback_data="approvals:unapprove"),
+        ],
+        [InlineKeyboardButton("📋 List", callback_data="approvals:list")],
+        [InlineKeyboardButton("⬅️ Back", callback_data="main:menu")],
+    ])

--- a/buttons/filters.py
+++ b/buttons/filters.py
@@ -1,0 +1,13 @@
+from pyrogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+
+
+def filters_panel() -> InlineKeyboardMarkup:
+    """Markup for the Filters module."""
+    return InlineKeyboardMarkup([
+        [
+            InlineKeyboardButton("➕ Add", callback_data="filters:add"),
+            InlineKeyboardButton("➖ Remove", callback_data="filters:remove"),
+        ],
+        [InlineKeyboardButton("📃 List", callback_data="filters:list")],
+        [InlineKeyboardButton("⬅️ Back", callback_data="main:menu")],
+    ])

--- a/buttons/lock.py
+++ b/buttons/lock.py
@@ -1,0 +1,12 @@
+from pyrogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+
+
+def lock_panel() -> InlineKeyboardMarkup:
+    """Markup for the Lock module."""
+    return InlineKeyboardMarkup([
+        [
+            InlineKeyboardButton("🔒 Lock", callback_data="lock:lock"),
+            InlineKeyboardButton("🔓 Unlock", callback_data="lock:unlock"),
+        ],
+        [InlineKeyboardButton("⬅️ Back", callback_data="main:menu")],
+    ])

--- a/buttons/rules.py
+++ b/buttons/rules.py
@@ -1,0 +1,13 @@
+from pyrogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+
+
+def rules_panel() -> InlineKeyboardMarkup:
+    """Markup for the Rules module."""
+    return InlineKeyboardMarkup([
+        [
+            InlineKeyboardButton("📜 View", callback_data="rules:view"),
+            InlineKeyboardButton("📝 Set", callback_data="rules:set"),
+        ],
+        [InlineKeyboardButton("🔘 Button", callback_data="rules:button")],
+        [InlineKeyboardButton("⬅️ Back", callback_data="main:menu")],
+    ])

--- a/buttons/warnings.py
+++ b/buttons/warnings.py
@@ -1,0 +1,13 @@
+from pyrogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+
+
+def warnings_panel() -> InlineKeyboardMarkup:
+    """Markup for the Warnings module."""
+    return InlineKeyboardMarkup([
+        [
+            InlineKeyboardButton("⚠️ Warn", callback_data="warnings:warn"),
+            InlineKeyboardButton("🔢 Limit", callback_data="warnings:limit"),
+        ],
+        [InlineKeyboardButton("⚙️ Settings", callback_data="warnings:settings")],
+        [InlineKeyboardButton("⬅️ Back", callback_data="main:menu")],
+    ])

--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -1,5 +1,6 @@
 from pyrogram import Client, filters
-from pyrogram.types import Message
+from pyrogram.types import Message, CallbackQuery
+from pyrogram.handlers import CallbackQueryHandler
 from utils.decorators import is_admin
 from utils.db import set_chat_setting, get_chat_setting
 from buttons.admin import admin_panel
@@ -97,6 +98,20 @@ async def admin_menu(client: Client, message: Message):
         parse_mode="markdown",
     )
 
+# Callback buttons from the admin panel
+async def admin_cb(client: Client, query: CallbackQuery):
+    data = query.data.split(":")[1]
+    if data == "promote":
+        text = "Reply with /promote to give admin rights."
+    elif data == "demote":
+        text = "Reply with /demote to remove admin rights."
+    elif data == "list":
+        text = "Use /adminlist to see all admins."
+    else:
+        text = "Unknown command."
+    await query.message.edit_text(text, reply_markup=admin_panel(), parse_mode="markdown")
+    await query.answer()
+
 def register(app: Client):
     app.add_handler(filters.command("promote") & filters.group, promote)
     app.add_handler(filters.command("demote") & filters.group, demote)
@@ -105,3 +120,4 @@ def register(app: Client):
     app.add_handler(filters.command("anonadmin") & filters.group, anonadmin)
     app.add_handler(filters.command("adminerror") & filters.group, adminerror)
     app.add_handler(filters.command("admin") & filters.group, admin_menu)
+    app.add_handler(CallbackQueryHandler(admin_cb, filters.regex(r"^admin:(?!open$).+")))

--- a/handlers/approval.py
+++ b/handlers/approval.py
@@ -1,5 +1,7 @@
 from pyrogram import Client, filters
-from pyrogram.types import Message
+from pyrogram.types import Message, CallbackQuery
+from pyrogram.handlers import CallbackQueryHandler
+from buttons.approvals import approvals_panel
 from utils.decorators import admin_required
 
 # Temporary in-memory store (use DB in production)
@@ -56,3 +58,19 @@ async def clear_approved(client: Client, message: Message):
     chat_id = message.chat.id
     APPROVED_USERS[chat_id] = set()
     await message.reply_text("✅ All approved users have been cleared.")
+
+
+# Callback handler for approvals panel
+@Client.on_callback_query(filters.regex(r"^approvals:(?!open$).+"))
+async def approvals_cb(client: Client, query: CallbackQuery):
+    data = query.data.split(":")[1]
+    if data == "approve":
+        text = "Reply with /approve to approve a user."
+    elif data == "unapprove":
+        text = "Reply with /unapprove to revoke approval."
+    elif data == "list":
+        text = "Use /approved to list approved users."
+    else:
+        text = "Unknown command."
+    await query.message.edit_text(text, reply_markup=approvals_panel(), parse_mode="markdown")
+    await query.answer()

--- a/handlers/locks.py
+++ b/handlers/locks.py
@@ -1,6 +1,8 @@
 from pyrogram import Client, filters, types
-from pyrogram.handlers import MessageHandler
+from pyrogram.handlers import MessageHandler, CallbackQueryHandler
 from utils.decorators import admin_required
+from pyrogram.types import CallbackQuery
+from buttons.lock import lock_panel
 
 # Define supported lock types and their corresponding permission flags
 LOCK_MAP = {
@@ -92,6 +94,20 @@ async def unlock_cmd(client: Client, message: types.Message):
     await message.reply_text(f"🔓 Unlocked `{lock_type}`.", parse_mode="markdown")
 
 
+# Callbacks from lock panel
+async def lock_cb(client: Client, query: CallbackQuery):
+    data = query.data.split(":")[1]
+    if data == "lock":
+        text = "Use /lock <type> to lock something."
+    elif data == "unlock":
+        text = "Use /unlock <type> to unlock."
+    else:
+        text = "Unknown command."
+    await query.message.edit_text(text, reply_markup=lock_panel(), parse_mode="markdown")
+    await query.answer()
+
+
 def register(app: Client):
     app.add_handler(MessageHandler(lock_cmd, filters.command("lock") & filters.group))
     app.add_handler(MessageHandler(unlock_cmd, filters.command("unlock") & filters.group))
+    app.add_handler(CallbackQueryHandler(lock_cb, filters.regex(r"^lock:(?!open$).+")))

--- a/handlers/misc.py
+++ b/handlers/misc.py
@@ -11,39 +11,66 @@ MODULE_BUTTONS = [
     ("⚠️ Warnings", "warnings:open"),
     ("✅ Approvals", "approvals:open"),
     ("🔒 Lock", "lock:open"),
+    ("📝 Notes", "notes:open"),
 ]
+
+
+def build_menu() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        [[InlineKeyboardButton(text, callback_data=cb)] for text, cb in MODULE_BUTTONS]
+    )
+
+from buttons import (
+    admin_panel,
+    filters_panel,
+    rules_panel,
+    warnings_panel,
+    approvals_panel,
+    lock_panel,
+    notes_panel,
+)
+
+MODULE_PANELS = {
+    "admin": admin_panel,
+    "filters": filters_panel,
+    "rules": rules_panel,
+    "warnings": warnings_panel,
+    "approvals": approvals_panel,
+    "lock": lock_panel,
+    "notes": notes_panel,
+}
 
 # Start command
 async def start(client: Client, message: Message):
     await message.reply_text(
-        "**🌹 Rose Bot**\nI help moderate and protect your group.\nUse /menu to view control panel.",
+        "**🌹 Rose Bot**\nI help moderate and protect your group.",
+        reply_markup=build_menu(),
         quote=True,
     )
 
 # Menu control panel
 async def menu(client: Client, message: Message):
-    markup = InlineKeyboardMarkup(
-        [[InlineKeyboardButton(text, callback_data=cb)] for text, cb in MODULE_BUTTONS]
-    )
-    await message.reply_text("**📋 Control Panel**", reply_markup=markup, quote=True)
+    await message.reply_text("**📋 Control Panel**", reply_markup=build_menu(), quote=True)
 
 # Panel open handler
 async def panel_open(client: Client, query: CallbackQuery):
     module = query.data.split(":")[0]
+    panel_func = MODULE_PANELS.get(module)
+    markup = panel_func() if panel_func else InlineKeyboardMarkup(
+        [[InlineKeyboardButton("⬅️ Back", callback_data="main:menu")]]
+    )
     await query.message.edit_text(
         f"**🔧 {module.title()} Panel**",
-        reply_markup=InlineKeyboardMarkup(
-            [[InlineKeyboardButton("⬅️ Back", callback_data="main:menu")]]
-        )
+        reply_markup=markup,
+        parse_mode="markdown",
     )
     await query.answer()
 
 # Back to main menu
 async def menu_cb(client: Client, query: CallbackQuery):
-    markup = InlineKeyboardMarkup(
-        [[InlineKeyboardButton(text, callback_data=cb)] for text, cb in MODULE_BUTTONS]
+    await query.message.edit_text(
+        "**📋 Control Panel**", reply_markup=build_menu(), parse_mode="markdown"
     )
-    await query.message.edit_text("**📋 Control Panel**", reply_markup=markup)
     await query.answer()
 
 # Random run messages

--- a/handlers/notes.py
+++ b/handlers/notes.py
@@ -139,4 +139,4 @@ def register(app: Client):
     app.add_handler(MessageHandler(private_notes_toggle, filters.command("privatenotes") & filters.group))
     app.add_handler(MessageHandler(get_note_cmd, filters.command("get") & filters.group))
     app.add_handler(MessageHandler(get_note_hash, filters.text & filters.group))
-    app.add_handler(CallbackQueryHandler(notes_cb, filters.regex("^notes:")))
+    app.add_handler(CallbackQueryHandler(notes_cb, filters.regex("^notes:(?!open$)")))

--- a/handlers/rules.py
+++ b/handlers/rules.py
@@ -2,7 +2,8 @@ from pyrogram import Client, filters
 from pyrogram.handlers import MessageHandler, CallbackQueryHandler
 from utils.decorators import admin_required
 from utils.db import set_chat_setting, get_chat_setting
-from pyrogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+from pyrogram.types import InlineKeyboardMarkup, InlineKeyboardButton, CallbackQuery
+from buttons.rules import rules_panel
 
 
 # /rules - shows rules in group or PM
@@ -76,6 +77,21 @@ async def rules_back(client, query):
     await query.answer()
 
 
+# Inline callbacks from rules panel
+async def rules_cb(client: Client, query: CallbackQuery):
+    data = query.data.split(":")[1]
+    if data == "view":
+        text = "Send /rules to view the current rules."
+    elif data == "set":
+        text = "Use /setrules or reply with the rules text and /setrules to set it."
+    elif data == "button":
+        text = "Use /setrulesbutton to set the rules button label."
+    else:
+        text = "Unknown command."
+    await query.message.edit_text(text, reply_markup=rules_panel(), parse_mode="markdown")
+    await query.answer()
+
+
 # Register handlers
 def register(app: Client):
     app.add_handler(MessageHandler(rules_cmd, filters.command('rules') & (filters.group | filters.private)))
@@ -85,3 +101,4 @@ def register(app: Client):
     app.add_handler(MessageHandler(set_rules_button, filters.command('setrulesbutton') & filters.group))
     app.add_handler(MessageHandler(reset_rules_button, filters.command('resetrulesbutton') & filters.group))
     app.add_handler(CallbackQueryHandler(rules_back, filters.regex('^rules:back')))
+    app.add_handler(CallbackQueryHandler(rules_cb, filters.regex(r'^rules:(?!open$).+')))


### PR DESCRIPTION
## Summary
- enable new module panels for filters, rules, warnings, approvals, locks and notes
- add callbacks for module buttons
- refactor menu creation and show on /start
- wire control panel buttons to custom panels

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_687c920152fc8329a164aadfcb2c46cb