### PR TITLE
Fix markdown parse errors

### DIFF
--- a/handlers/federations.py
+++ b/handlers/federations.py
@@ -1,5 +1,6 @@
 from pyrogram import Client, filters
 from pyrogram.types import Message
+from utils.markdown import escape_markdown
 from utils.decorators import admin_required
 
 # In-memory storage (replace with DB later)
@@ -22,7 +23,10 @@ async def create_fed(client: Client, message: Message):
     user_id = message.from_user.id
     FEDERATIONS[fed_name] = {"owner": user_id, "banned_users": set()}
     USER_TO_FEDS.setdefault(user_id, set()).add(fed_name)
-    await message.reply_text(f"✅ Federation `{fed_name}` has been created.", parse_mode="markdown")
+    safe = escape_markdown(fed_name)
+    await message.reply_text(
+        f"✅ Federation `{safe}` has been created.", parse_mode="markdown"
+    )
 
 
 @Client.on_message(filters.command("joinfed") & filters.group)
@@ -38,7 +42,10 @@ async def join_fed(client: Client, message: Message):
         return
 
     GROUP_TO_FED[message.chat.id] = fed_name
-    await message.reply_text(f"✅ This group has joined the `{fed_name}` federation.", parse_mode="markdown")
+    safe = escape_markdown(fed_name)
+    await message.reply_text(
+        f"✅ This group has joined the `{safe}` federation.", parse_mode="markdown"
+    )
 
 
 @Client.on_message(filters.command("leavefed") & filters.group)
@@ -49,7 +56,10 @@ async def leave_fed(client: Client, message: Message):
         return
 
     fed_name = GROUP_TO_FED.pop(message.chat.id)
-    await message.reply_text(f"🚪 Group left the `{fed_name}` federation.", parse_mode="markdown")
+    safe = escape_markdown(fed_name)
+    await message.reply_text(
+        f"🚪 Group left the `{safe}` federation.", parse_mode="markdown"
+    )
 
 
 @Client.on_message(filters.command("federations"))
@@ -82,7 +92,10 @@ async def fed_ban(client: Client, message: Message):
 
     user_id = message.reply_to_message.from_user.id
     FEDERATIONS[fed_name]["banned_users"].add(user_id)
-    await message.reply_text(f"🚫 User `{user_id}` has been FedBanned in `{fed_name}`.", parse_mode="markdown")
+    safe = escape_markdown(fed_name)
+    await message.reply_text(
+        f"🚫 User `{user_id}` has been FedBanned in `{safe}`.", parse_mode="markdown"
+    )
 
 
 @Client.on_message(filters.command("fedunban") & filters.group)
@@ -100,7 +113,10 @@ async def fed_unban(client: Client, message: Message):
 
     user_id = message.reply_to_message.from_user.id
     FEDERATIONS[fed_name]["banned_users"].discard(user_id)
-    await message.reply_text(f"✅ User `{user_id}` has been FedUnbanned in `{fed_name}`.", parse_mode="markdown")
+    safe = escape_markdown(fed_name)
+    await message.reply_text(
+        f"✅ User `{user_id}` has been FedUnbanned in `{safe}`.", parse_mode="markdown"
+    )
 
 
 @Client.on_message(filters.new_chat_members)

--- a/handlers/filters.py
+++ b/handlers/filters.py
@@ -1,5 +1,6 @@
 from pyrogram import Client, filters
 from pyrogram.types import Message, CallbackQuery
+from utils.markdown import escape_markdown
 from pyrogram.handlers import MessageHandler, CallbackQueryHandler
 from buttons.filters import filters_panel
 from utils.decorators import is_admin
@@ -16,7 +17,10 @@ async def add_filter_cmd(client: Client, message: Message):
     response = " ".join(message.command[2:])
 
     add_filter(message.chat.id, keyword, response)
-    await message.reply_text(f"✅ Filter `\"{keyword}\"` added.", parse_mode="markdown")
+    safe_key = escape_markdown(keyword)
+    await message.reply_text(
+        f"✅ Filter `\"{safe_key}\"` added.", parse_mode="markdown"
+    )
 
 
 @is_admin
@@ -27,7 +31,10 @@ async def stop_filter_cmd(client: Client, message: Message):
 
     keyword = message.command[1].lower()
     remove_filter(message.chat.id, keyword)
-    await message.reply_text(f"🗑️ Removed filter `\"{keyword}\"`.", parse_mode="markdown")
+    safe_key = escape_markdown(keyword)
+    await message.reply_text(
+        f"🗑️ Removed filter `\"{safe_key}\"`.", parse_mode="markdown"
+    )
 
 
 async def list_filters_cmd(client: Client, message: Message):

--- a/handlers/logchannel.py
+++ b/handlers/logchannel.py
@@ -2,6 +2,7 @@ from pyrogram import Client, filters
 from pyrogram.types import Message
 from utils.decorators import admin_required
 from utils.db import set_chat_setting, get_chat_setting
+from utils.markdown import escape_markdown
 
 @Client.on_message(filters.command("logchannel") & filters.group)
 @admin_required
@@ -9,7 +10,10 @@ async def logchannel_handler(client: Client, message: Message):
     if len(message.command) == 1:
         log_id = get_chat_setting(message.chat.id, "log_channel")
         if log_id:
-            await message.reply_text(f"📝 Log channel is set to: `{log_id}`", parse_mode="markdown")
+            safe_id = escape_markdown(str(log_id))
+            await message.reply_text(
+                f"📝 Log channel is set to: `{safe_id}`", parse_mode="markdown"
+            )
         else:
             await message.reply_text("ℹ️ No log channel set.")
         return
@@ -39,10 +43,17 @@ async def logchannel_handler(client: Client, message: Message):
             return
 
         set_chat_setting(message.chat.id, "log_channel", chat.id)
-        await message.reply_text(f"✅ Logs will be sent to: `{chat.title}` (`{chat.id}`)", parse_mode="markdown")
+        safe_title = escape_markdown(chat.title)
+        await message.reply_text(
+            f"✅ Logs will be sent to: `{safe_title}` (`{chat.id}`)",
+            parse_mode="markdown",
+        )
 
     except Exception as e:
-        await message.reply_text(f"❌ Failed to set log channel:\n`{e}`", parse_mode="markdown")
+        safe_err = escape_markdown(str(e))
+        await message.reply_text(
+            f"❌ Failed to set log channel:\n`{safe_err}`", parse_mode="markdown"
+        )
 
 
 # Util function used in other modules (e.g., warnings, filters, bans, etc.)

--- a/handlers/pin.py
+++ b/handlers/pin.py
@@ -2,6 +2,7 @@ from pyrogram import Client, filters
 from pyrogram.handlers import MessageHandler
 from utils.decorators import admin_required
 from utils.db import set_chat_setting, get_chat_setting
+from utils.markdown import escape_markdown
 
 
 # Show current pinned message
@@ -64,7 +65,11 @@ async def unpin_all_cmd(client: Client, message):
 async def antichannelpin_cmd(client: Client, message):
     if len(message.command) == 1:
         state = get_chat_setting(message.chat.id, "antichannelpin", "off")
-        await message.reply(f"📡 Anti-channel pin is currently `{state}`.", parse_mode="markdown")
+        safe_state = escape_markdown(state)
+        await message.reply(
+            f"📡 Anti-channel pin is currently `{safe_state}`.",
+            parse_mode="markdown",
+        )
         return
 
     value = message.command[1].lower()
@@ -73,7 +78,10 @@ async def antichannelpin_cmd(client: Client, message):
         return
 
     set_chat_setting(message.chat.id, "antichannelpin", value)
-    await message.reply(f"📡 Anti-channel pin set to `{value}`.", parse_mode="markdown")
+    safe_val = escape_markdown(value)
+    await message.reply(
+        f"📡 Anti-channel pin set to `{safe_val}`.", parse_mode="markdown"
+    )
 
 
 # Enable or disable clean linked messages (auto-delete 'linked to this message' messages)
@@ -81,7 +89,10 @@ async def antichannelpin_cmd(client: Client, message):
 async def cleanlinked_cmd(client: Client, message):
     if len(message.command) == 1:
         state = get_chat_setting(message.chat.id, "cleanlinked", "off")
-        await message.reply(f"🧼 Clean linked messages is `{state}`.", parse_mode="markdown")
+        safe_state = escape_markdown(state)
+        await message.reply(
+            f"🧼 Clean linked messages is `{safe_state}`.", parse_mode="markdown"
+        )
         return
 
     value = message.command[1].lower()
@@ -90,7 +101,10 @@ async def cleanlinked_cmd(client: Client, message):
         return
 
     set_chat_setting(message.chat.id, "cleanlinked", value)
-    await message.reply(f"🧼 Clean linked messages set to `{value}`.", parse_mode="markdown")
+    safe_val = escape_markdown(value)
+    await message.reply(
+        f"🧼 Clean linked messages set to `{safe_val}`.", parse_mode="markdown"
+    )
 
 
 # Register all command handlers

--- a/utils/markdown.py
+++ b/utils/markdown.py
@@ -1,0 +1,9 @@
+"""Utilities for Telegram Markdown formatting."""
+
+def escape_markdown(text: str) -> str:
+    """Escape special characters for Telegram Markdown V2."""
+    if not isinstance(text, str):
+        return text
+    for ch in ("_", "*", "[", "]", "(", ")", "~", "`", ">", "#", "+", "-", "=", "|", "{", "}", ".", "!"):
+        text = text.replace(ch, f"\\{ch}")
+    return text


### PR DESCRIPTION
## Summary
- escape user-supplied values before sending Markdown-formatted messages
- add helper `escape_markdown`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687c954c16e08329b4b7c1efd3791423