### PR TITLE
Enhance approval system and misc commands

### DIFF
--- a/handlers/help.py
+++ b/handlers/help.py
@@ -11,6 +11,8 @@ HELP_MODULES = {
     "markdownhelp": "Send a short guide about Markdown formatting.",
     "limits": "Show current bot limitations.",
     "runs": "Send a random running away message.",
+    "ping": "Check bot responsiveness.",
+    "echo": "Echo back your text.",
     "privacy": "Show the bot privacy policy.",
 
     "save": "Save a note. Reply or use `/save name text`.",
@@ -62,6 +64,12 @@ HELP_MODULES = {
     "privaterules": "Toggle sending rules in PM instead of chat.",
 
     "lock": "Lock a certain type of messages or actions in the chat.",
+
+    "approve": "Approve a user to bypass restrictions.",
+    "unapprove": "Revoke a previously approved user.",
+    "approved": "List approved users in the chat.",
+    "clearapproved": "Clear all approved users.",
+    "approvalmode": "Toggle approval-only mode for regular users.",
 }
 
 # Dynamic help menu builder

--- a/handlers/misc2.py
+++ b/handlers/misc2.py
@@ -1,5 +1,20 @@
 from pyrogram import Client, filters
+from pyrogram.handlers import MessageHandler
+from pyrogram.types import Message
+import time
 
-@Client.on_message(filters.command('misc2'))
-async def placeholder(_, m):
-    await m.reply('Misc2 module not implemented yet.')
+# Simple misc commands
+
+@Client.on_message(filters.command("ping"))
+async def ping(client: Client, message: Message):
+    start = time.monotonic()
+    reply = await message.reply_text("Pong!")
+    end = time.monotonic()
+    await reply.edit_text(f"Pong! `{(end - start) * 1000:.0f}ms`", parse_mode="markdown")
+
+@Client.on_message(filters.command("echo"))
+async def echo(client: Client, message: Message):
+    if len(message.command) < 2:
+        await message.reply_text("Usage: `/echo <text>`", parse_mode="markdown")
+        return
+    await message.reply_text(" ".join(message.command[1:]))

--- a/utils/db.py
+++ b/utils/db.py
@@ -150,6 +150,48 @@ async def is_approved(chat_id: int, user_id: int) -> bool:
         return bool(row)
 
 
+async def add_approval(chat_id: int, user_id: int) -> None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "CREATE TABLE IF NOT EXISTS approvals (chat_id INTEGER, user_id INTEGER, PRIMARY KEY(chat_id, user_id))"
+        )
+        await db.execute(
+            "REPLACE INTO approvals (chat_id, user_id) VALUES (?, ?)",
+            (chat_id, user_id),
+        )
+        await db.commit()
+
+
+async def remove_approval(chat_id: int, user_id: int) -> None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "DELETE FROM approvals WHERE chat_id=? AND user_id=?",
+            (chat_id, user_id),
+        )
+        await db.commit()
+
+
+async def list_approvals(chat_id: int) -> list[int]:
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "CREATE TABLE IF NOT EXISTS approvals (chat_id INTEGER, user_id INTEGER, PRIMARY KEY(chat_id, user_id))"
+        )
+        rows = await db.execute_fetchall(
+            "SELECT user_id FROM approvals WHERE chat_id=?",
+            (chat_id,),
+        )
+        return [r[0] for r in rows]
+
+
+async def clear_approvals(chat_id: int) -> None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "DELETE FROM approvals WHERE chat_id=?",
+            (chat_id,),
+        )
+        await db.commit()
+
+
 async def get_approval_mode(chat_id: int) -> bool:
     # stored in settings table as approval_mode=on|off
     val = await get_setting(chat_id, "approval_mode", "off")


### PR DESCRIPTION
## Summary
- persist approvals in SQLite with helper functions
- add /approvalmode command
- extend help panel for misc and approval commands
- replace misc2 placeholder with ping/echo commands

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_687ca5e04fb88329a3da9f904c25afa9