### PR TITLE
Improve bot startup error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This repository contains the source code for **Rose**, a modular Telegram bot bu
    ```bash
    python main.py
    ```
+   The bot will exit with an error message if any required credential is missing.
 
 ## Deployment
 Example files are provided for running on container platforms:

--- a/main.py
+++ b/main.py
@@ -25,6 +25,18 @@ API_HASH = os.environ.get("API_HASH", "YOUR_API_HASH")
 BOT_TOKEN = os.environ.get("BOT_TOKEN", "YOUR_BOT_TOKEN")
 SESSION_NAME = os.environ.get("SESSION_NAME", "rose_bot")
 
+# Abort early if credentials were not provided
+if (
+    API_ID == 123456 or
+    API_HASH == "YOUR_API_HASH" or
+    BOT_TOKEN == "YOUR_BOT_TOKEN"
+):
+    LOGGER.error(
+        "Missing API credentials. Please populate a .env file "
+        "or set the API_ID, API_HASH and BOT_TOKEN environment variables."
+    )
+    raise SystemExit(1)
+
 # Initialise the Pyrogram client
 app = Client(SESSION_NAME, api_id=API_ID, api_hash=API_HASH, bot_token=BOT_TOKEN)
 
@@ -48,7 +60,8 @@ async def main() -> None:
     except Exception:
         LOGGER.exception("Bot stopped due to an unexpected error")
     finally:
-        await app.stop()
+        if app.is_connected:
+            await app.stop()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- check for missing API credentials and exit
- only stop client when connected
- document credential check in README

## Testing
- `python main.py > /tmp/bot.log 2>&1 && tail -n 20 /tmp/bot.log`

------
https://chatgpt.com/codex/tasks/task_b_687ca9dd73c88329bb2b40ee0341530f