### PR TITLE
Fix log group configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,6 @@ API_HASH=your_api_hash
 BOT_TOKEN=your_bot_token
 MONGO_URL=mongodb://localhost:27017/rose
 SESSION_NAME=rose_bot
+LOG_GROUP_ID=
+OWNER_ID=
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This repository contains the source code for **Rose**, a modular Telegram bot bu
    pip install -r requirements.txt
    ```
 2. Copy `.env.example` to `.env` and fill in your credentials.
+   Optionally set `LOG_GROUP_ID` to a Telegram group or channel ID to
+   receive startup and crash logs.
 3. Start the bot:
    ```bash
    python main.py

--- a/config.py
+++ b/config.py
@@ -7,6 +7,13 @@ API_ID = int(os.environ.get("API_ID", "123456"))
 API_HASH = os.environ.get("API_HASH", "YOUR_API_HASH")
 BOT_TOKEN = os.environ.get("BOT_TOKEN", "YOUR_BOT_TOKEN")
 
-# Directly assign fixed values here
-OWNER_ID = 1888832817  # Replace with your actual Telegram user ID
-LOG_GROUP_ID = -1002867268050  # Replace with your actual group/channel ID
+OWNER_ID = (
+    int(os.environ.get("OWNER_ID", "0"))
+    if os.environ.get("OWNER_ID")
+    else None
+)
+LOG_GROUP_ID = (
+    int(os.environ.get("LOG_GROUP_ID", "0"))
+    if os.environ.get("LOG_GROUP_ID")
+    else None
+)


### PR DESCRIPTION
## Summary
- update config to read OWNER_ID and LOG_GROUP_ID from environment variables
- document LOG_GROUP_ID in README and `.env.example`

## Testing
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_687caf103e708329885962ce2d034402