### PR TITLE
Fix text formatting and imports for command handlers

### DIFF
--- a/handlers/connections.py
+++ b/handlers/connections.py
@@ -1,6 +1,5 @@
 from pyrogram import Client, filters
 from pyrogram.types import Message
-from utils.db import set_chat_setting, get_chat_setting
 from utils.decorators import admin_required
 
 # Temporary in-memory map (user_id: chat_id)
@@ -13,7 +12,7 @@ async def connect_group(client: Client, message: Message):
     chat_id = message.chat.id
 
     CONNECTIONS[user_id] = chat_id
-    await message.reply_text(f"🔗 Group connected! You can now use group commands in private chat.")
+    await message.reply_text("🔗 Group connected! You can now use group commands in private chat.")
 
 @Client.on_message(filters.command("disconnect") & filters.group)
 @admin_required

--- a/handlers/greetings.py
+++ b/handlers/greetings.py
@@ -30,7 +30,7 @@ async def show_greetings(client: Client, message: Message):
     welcome = get_chat_setting(message.chat.id, "welcome", "Not set.")
     goodbye = get_chat_setting(message.chat.id, "goodbye", "Not set.")
 
-    msg = f"**👋 Greetings Settings:**\n"
+    msg = "**👋 Greetings Settings:**\n"
     msg += f"• **Welcome:** `{welcome}`\n"
     msg += f"• **Goodbye:** `{goodbye}`"
     await message.reply_text(msg, parse_mode="markdown")


### PR DESCRIPTION
## Summary
- clean up unused imports and minor issues
- fix f-string usage in connections and greetings modules

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 handlers/connections.py handlers/greetings.py --ignore=E501`

------
https://chatgpt.com/codex/tasks/task_b_687d27b4d17c832993bac458cbb3232c