### PR TITLE
Fix owner id handling for broadcast command

### DIFF
--- a/handlers/broadcast.py
+++ b/handlers/broadcast.py
@@ -18,6 +18,10 @@ logger = logging.getLogger(__name__)
 def register(app: Client) -> None:
     logger.info("✅ Registered: broadcast.py")
 
+    if OWNER_ID is None:
+        logger.warning("OWNER_ID not set; disabling /broadcast")
+        return
+
     @app.on_message(filters.command("broadcast") & filters.user(OWNER_ID))
     @catch_errors
     async def broadcast_cmd(client: Client, message: Message) -> None:


### PR DESCRIPTION
## Summary
- disable /broadcast registration when OWNER_ID isn't set

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_687dfd45aefc8329bd30946d39308ac2