### PR TITLE
Add unified start/help/menu module

### DIFF
--- a/handlers/help.py
+++ b/handlers/help.py
@@ -1,6 +1,4 @@
-from pyrogram import Client, filters
-from pyrogram.types import Message, CallbackQuery, InlineKeyboardMarkup, InlineKeyboardButton
-from pyrogram.handlers import MessageHandler, CallbackQueryHandler
+"""Help module descriptions used by the start module."""
 
 # Individual command descriptions for the help panel
 HELP_MODULES = {
@@ -72,48 +70,4 @@ HELP_MODULES = {
     "approvalmode": "Toggle approval-only mode for regular users.",
 }
 
-# Dynamic help menu builder
-def help_menu() -> InlineKeyboardMarkup:
-    keys = []
-    temp = []
-    for i, mod in enumerate(sorted(HELP_MODULES.keys())):
-        temp.append(InlineKeyboardButton(mod.title(), callback_data=f"help:{mod}"))
-        if len(temp) == 2:
-            keys.append(temp)
-            temp = []
-    if temp:
-        keys.append(temp)
-    keys.append([InlineKeyboardButton("❌ Close", callback_data="help:close")])
-    return InlineKeyboardMarkup(keys)
-
-# /help command
-async def help_cmd(client: Client, message: Message):
-    if len(message.command) > 1:
-        mod = message.command[1].lower()
-        if mod in HELP_MODULES:
-            await message.reply_text(f"{HELP_MODULES[mod]}", reply_markup=help_menu(), parse_mode="markdown")
-        else:
-            await message.reply_text("❌ Unknown module.")
-        return
-
-    await message.reply_text(
-        "**🛠 Help Panel**\nClick a button below to view module commands:",
-        reply_markup=help_menu(),
-        parse_mode="markdown"
-    )
-
-# Inline button callback
-async def help_cb(client: Client, query: CallbackQuery):
-    mod = query.data.split(":")[1]
-    if mod == "close":
-        await query.message.delete()
-        return
-
-    text = HELP_MODULES.get(mod, "❌ Module not found.")
-    await query.message.edit_text(text, reply_markup=help_menu(), parse_mode="markdown")
-    await query.answer()
-
-# Register handlers
-def register(app: Client):
-    app.add_handler(MessageHandler(help_cmd, filters.command("help")))
-    app.add_handler(CallbackQueryHandler(help_cb, filters.regex(r"^help:.+")))
+# The actual /help command logic is now implemented in ``handlers.start``.

--- a/handlers/misc.py
+++ b/handlers/misc.py
@@ -1,103 +1,7 @@
 import random
 from pyrogram import Client, filters
-from pyrogram.handlers import MessageHandler, CallbackQueryHandler
-from pyrogram.types import Message, CallbackQuery, InlineKeyboardMarkup, InlineKeyboardButton
-
-# Control panel button layout
-MODULE_BUTTONS = [
-    ("⚙️ Admin", "admin:open"),
-    ("💬 Filters", "filters:open"),
-    ("📜 Rules", "rules:open"),
-    ("⚠️ Warnings", "warnings:open"),
-    ("✅ Approvals", "approvals:open"),
-    ("🔒 Lock", "lock:open"),
-    ("📝 Notes", "notes:open"),
-]
-
-
-def build_menu() -> InlineKeyboardMarkup:
-    """Return the main control panel keyboard."""
-
-    keys = []
-    temp = []
-    for text, cb in MODULE_BUTTONS:
-        temp.append(InlineKeyboardButton(text, callback_data=cb))
-        if len(temp) == 2:
-            keys.append(temp)
-            temp = []
-    if temp:
-        keys.append(temp)
-    keys.append([InlineKeyboardButton("❌ Close", callback_data="main:close")])
-    return InlineKeyboardMarkup(keys)
-
-from buttons import (
-    admin_panel,
-    filters_panel,
-    rules_panel,
-    warnings_panel,
-    approvals_panel,
-    lock_panel,
-    notes_panel,
-)
-
-MODULE_PANELS = {
-    "admin": admin_panel,
-    "filters": filters_panel,
-    "rules": rules_panel,
-    "warnings": warnings_panel,
-    "approvals": approvals_panel,
-    "lock": lock_panel,
-    "notes": notes_panel,
-}
-
-# Start command
-async def start(client: Client, message: Message):
-    await message.reply_text(
-        "**🌹 Rose Bot**\nI help moderate and protect your group.",
-        reply_markup=InlineKeyboardMarkup(
-            [[InlineKeyboardButton("📋 Menu", callback_data="menu:open")]]
-        ),
-        quote=True,
-    )
-
-# Menu control panel
-async def menu(client: Client, message: Message):
-    await message.reply_text("**📋 Control Panel**", reply_markup=build_menu(), quote=True)
-
-async def menu_open(client: Client, query: CallbackQuery):
-    await query.message.edit_text(
-        "**📋 Control Panel**",
-        reply_markup=build_menu(),
-        parse_mode="markdown",
-    )
-    await query.answer()
-
-# Panel open handler
-async def panel_open(client: Client, query: CallbackQuery):
-    module = query.data.split(":")[0]
-    panel_func = MODULE_PANELS.get(module)
-    markup = panel_func() if panel_func else InlineKeyboardMarkup(
-        [[InlineKeyboardButton("⬅️ Back", callback_data="main:menu")]]
-    )
-    await query.message.edit_text(
-        f"**🔧 {module.title()} Panel**",
-        reply_markup=markup,
-        parse_mode="markdown",
-    )
-    await query.answer()
-
-# Back to main menu
-async def menu_cb(client: Client, query: CallbackQuery):
-    await query.message.edit_text(
-        "**📋 Control Panel**", reply_markup=build_menu(), parse_mode="markdown"
-    )
-    await query.answer()
-
-
-# Close the panel
-async def close_cb(client: Client, query: CallbackQuery):
-    await query.message.delete()
-    await query.answer()
+from pyrogram.handlers import MessageHandler
+from pyrogram.types import Message
 
 # Random run messages
 RUN_STRINGS = [
@@ -154,16 +58,9 @@ async def limits(client: Client, message: Message):
 
 # Register all handlers
 def register(app: Client):
-    app.add_handler(MessageHandler(start, filters.command("start")))
-    app.add_handler(MessageHandler(menu, filters.command("menu")))
     app.add_handler(MessageHandler(runs, filters.command("runs")))
     app.add_handler(MessageHandler(get_id, filters.command("id")))
     app.add_handler(MessageHandler(info, filters.command("info")))
     app.add_handler(MessageHandler(donate, filters.command("donate")))
     app.add_handler(MessageHandler(markdown_help, filters.command("markdownhelp")))
     app.add_handler(MessageHandler(limits, filters.command("limits")))
-
-    app.add_handler(CallbackQueryHandler(panel_open, filters.regex("^[a-z]+:open$")))
-    app.add_handler(CallbackQueryHandler(menu_open, filters.regex("^menu:open$")))
-    app.add_handler(CallbackQueryHandler(menu_cb, filters.regex("^main:menu$")))
-    app.add_handler(CallbackQueryHandler(close_cb, filters.regex("^main:close$")))

--- a/handlers/start.py
+++ b/handlers/start.py
@@ -1,0 +1,174 @@
+from pyrogram import Client, filters
+from pyrogram.handlers import MessageHandler, CallbackQueryHandler
+from pyrogram.types import (
+    Message,
+    CallbackQuery,
+    InlineKeyboardMarkup,
+    InlineKeyboardButton,
+)
+
+from .help import HELP_MODULES
+from buttons import (
+    admin_panel,
+    filters_panel,
+    rules_panel,
+    warnings_panel,
+    approvals_panel,
+    lock_panel,
+    notes_panel,
+)
+
+# --------------------------------------------------
+# Control panel button layout
+MODULE_BUTTONS = [
+    ("⚙️ Admin", "admin:open"),
+    ("💬 Filters", "filters:open"),
+    ("📜 Rules", "rules:open"),
+    ("⚠️ Warnings", "warnings:open"),
+    ("✅ Approvals", "approvals:open"),
+    ("🔒 Lock", "lock:open"),
+    ("📝 Notes", "notes:open"),
+]
+
+MODULE_PANELS = {
+    "admin": admin_panel,
+    "filters": filters_panel,
+    "rules": rules_panel,
+    "warnings": warnings_panel,
+    "approvals": approvals_panel,
+    "lock": lock_panel,
+    "notes": notes_panel,
+}
+
+
+def build_menu() -> InlineKeyboardMarkup:
+    """Return the main control panel keyboard."""
+    keys = []
+    temp = []
+    for text, cb in MODULE_BUTTONS:
+        temp.append(InlineKeyboardButton(text, callback_data=cb))
+        if len(temp) == 2:
+            keys.append(temp)
+            temp = []
+    if temp:
+        keys.append(temp)
+    keys.append([InlineKeyboardButton("❌ Close", callback_data="main:close")])
+    return InlineKeyboardMarkup(keys)
+
+
+# --------------------------------------------------
+# Help menu
+
+def help_menu() -> InlineKeyboardMarkup:
+    keys = []
+    temp = []
+    for mod in sorted(HELP_MODULES.keys()):
+        temp.append(InlineKeyboardButton(mod.title(), callback_data=f"help:{mod}"))
+        if len(temp) == 2:
+            keys.append(temp)
+            temp = []
+    if temp:
+        keys.append(temp)
+    keys.append([InlineKeyboardButton("❌ Close", callback_data="help:close")])
+    return InlineKeyboardMarkup(keys)
+
+
+# --------------------------------------------------
+# Commands
+
+async def start_cmd(client: Client, message: Message):
+    await message.reply_text(
+        "**🌹 Rose Bot**\nI help moderate and protect your group.",
+        reply_markup=InlineKeyboardMarkup(
+            [[InlineKeyboardButton("📋 Menu", callback_data="menu:open")]]
+        ),
+        quote=True,
+    )
+
+
+async def menu_cmd(client: Client, message: Message):
+    await message.reply_text("**📋 Control Panel**", reply_markup=build_menu(), quote=True)
+
+
+async def help_cmd(client: Client, message: Message):
+    if len(message.command) > 1:
+        mod = message.command[1].lower()
+        if mod in HELP_MODULES:
+            await message.reply_text(
+                HELP_MODULES[mod], reply_markup=help_menu(), parse_mode="markdown"
+            )
+        else:
+            await message.reply_text("❌ Unknown module.")
+        return
+
+    await message.reply_text(
+        "**🛠 Help Panel**\nClick a button below to view module commands:",
+        reply_markup=help_menu(),
+        parse_mode="markdown",
+    )
+
+
+# --------------------------------------------------
+# Callbacks
+
+async def menu_open_cb(client: Client, query: CallbackQuery):
+    await query.message.edit_text(
+        "**📋 Control Panel**",
+        reply_markup=build_menu(),
+        parse_mode="markdown",
+    )
+    await query.answer()
+
+
+async def panel_open_cb(client: Client, query: CallbackQuery):
+    module = query.data.split(":")[0]
+    panel_func = MODULE_PANELS.get(module)
+    markup = (
+        panel_func()
+        if panel_func
+        else InlineKeyboardMarkup([[InlineKeyboardButton("⬅️ Back", callback_data="main:menu")]])
+    )
+    await query.message.edit_text(
+        f"**🔧 {module.title()} Panel**",
+        reply_markup=markup,
+        parse_mode="markdown",
+    )
+    await query.answer()
+
+
+async def menu_cb(client: Client, query: CallbackQuery):
+    await query.message.edit_text(
+        "**📋 Control Panel**", reply_markup=build_menu(), parse_mode="markdown"
+    )
+    await query.answer()
+
+
+async def close_cb(client: Client, query: CallbackQuery):
+    await query.message.delete()
+    await query.answer()
+
+
+async def help_cb(client: Client, query: CallbackQuery):
+    mod = query.data.split(":")[1]
+    if mod == "close":
+        await query.message.delete()
+        return
+
+    text = HELP_MODULES.get(mod, "❌ Module not found.")
+    await query.message.edit_text(text, reply_markup=help_menu(), parse_mode="markdown")
+    await query.answer()
+
+
+# --------------------------------------------------
+# Registration helper
+
+def register(app: Client) -> None:
+    app.add_handler(MessageHandler(start_cmd, filters.command("start")))
+    app.add_handler(MessageHandler(menu_cmd, filters.command("menu")))
+    app.add_handler(MessageHandler(help_cmd, filters.command("help")))
+
+    app.add_handler(CallbackQueryHandler(panel_open_cb, filters.regex("^[a-z]+:open$")))
+    app.add_handler(CallbackQueryHandler(menu_open_cb, filters.regex("^menu:open$")))
+    app.add_handler(CallbackQueryHandler(menu_cb, filters.regex("^main:menu$")))
+    app.add_handler(CallbackQueryHandler(close_cb, filters.regex("^main:close$")))
+    app.add_handler(CallbackQueryHandler(help_cb, filters.regex(r"^help:.+")))


### PR DESCRIPTION
## Summary
- create `handlers/start.py` to handle `/start`, `/help` and `/menu`
- migrate help text dictionary to be reused from `handlers.start`
- clean up `handlers.misc` to remove old start/menu callbacks

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_687dff75e8c88329a144ad3b57d8803c