### PR TITLE
Add register functions to command modules

### DIFF
--- a/handlers/blocklist.py
+++ b/handlers/blocklist.py
@@ -1,11 +1,11 @@
 from pyrogram import Client, filters
 from pyrogram.types import Message
+from pyrogram.handlers import MessageHandler
 from utils.decorators import admin_required
 
 # In-memory store for blocklisted words (extend to DB later)
 BLOCKLIST = {}  # chat_id: set of words
 
-@Client.on_message(filters.command("addblock") & filters.group)
 @admin_required
 async def add_blocked_word(client: Client, message: Message):
     if len(message.command) < 2:
@@ -18,7 +18,6 @@ async def add_blocked_word(client: Client, message: Message):
     await message.reply_text(f"🚫 Added `{word}` to blocklist.", parse_mode="markdown")
 
 
-@Client.on_message(filters.command("unblock") & filters.group)
 @admin_required
 async def remove_blocked_word(client: Client, message: Message):
     if len(message.command) < 2:
@@ -31,7 +30,6 @@ async def remove_blocked_word(client: Client, message: Message):
     await message.reply_text(f"✅ Removed `{word}` from blocklist.", parse_mode="markdown")
 
 
-@Client.on_message(filters.command("blocklist") & filters.group)
 @admin_required
 async def show_blocklist(client: Client, message: Message):
     chat_id = message.chat.id
@@ -47,14 +45,12 @@ async def show_blocklist(client: Client, message: Message):
     await message.reply_text(text, parse_mode="markdown")
 
 
-@Client.on_message(filters.command("clearblocklist") & filters.group)
 @admin_required
 async def clear_blocklist(client: Client, message: Message):
     chat_id = message.chat.id
     BLOCKLIST[chat_id] = set()
     await message.reply_text("🧹 Blocklist has been cleared.")
 
-@Client.on_message(filters.text & filters.group & ~filters.service)
 async def auto_delete_blocked(client: Client, message: Message):
     chat_id = message.chat.id
     words = BLOCKLIST.get(chat_id, set())
@@ -69,3 +65,13 @@ async def auto_delete_blocked(client: Client, message: Message):
             except Exception:
                 pass
             break
+
+
+def register(app: Client) -> None:
+    app.add_handler(MessageHandler(add_blocked_word, filters.command("addblock") & filters.group))
+    app.add_handler(MessageHandler(remove_blocked_word, filters.command("unblock") & filters.group))
+    app.add_handler(MessageHandler(show_blocklist, filters.command("blocklist") & filters.group))
+    app.add_handler(MessageHandler(clear_blocklist, filters.command("clearblocklist") & filters.group))
+    app.add_handler(
+        MessageHandler(auto_delete_blocked, filters.text & filters.group & ~filters.service)
+    )

--- a/handlers/connections.py
+++ b/handlers/connections.py
@@ -1,11 +1,11 @@
 from pyrogram import Client, filters
 from pyrogram.types import Message
+from pyrogram.handlers import MessageHandler
 from utils.decorators import admin_required
 
 # Temporary in-memory map (user_id: chat_id)
 CONNECTIONS = {}
 
-@Client.on_message(filters.command("connect") & filters.group)
 @admin_required
 async def connect_group(client: Client, message: Message):
     user_id = message.from_user.id
@@ -14,7 +14,6 @@ async def connect_group(client: Client, message: Message):
     CONNECTIONS[user_id] = chat_id
     await message.reply_text("🔗 Group connected! You can now use group commands in private chat.")
 
-@Client.on_message(filters.command("disconnect") & filters.group)
 @admin_required
 async def disconnect_group(client: Client, message: Message):
     user_id = message.from_user.id
@@ -24,7 +23,6 @@ async def disconnect_group(client: Client, message: Message):
     else:
         await message.reply_text("You’re not connected to this group.")
 
-@Client.on_message(filters.command("connections") & filters.private)
 async def show_connection(client: Client, message: Message):
     user_id = message.from_user.id
     chat_id = CONNECTIONS.get(user_id)
@@ -41,3 +39,9 @@ async def show_connection(client: Client, message: Message):
 # Utility to get connected group from a user in private
 def get_user_connection(user_id: int) -> int | None:
     return CONNECTIONS.get(user_id)
+
+
+def register(app: Client) -> None:
+    app.add_handler(MessageHandler(connect_group, filters.command("connect") & filters.group))
+    app.add_handler(MessageHandler(disconnect_group, filters.command("disconnect") & filters.group))
+    app.add_handler(MessageHandler(show_connection, filters.command("connections") & filters.private))

--- a/handlers/formatting.py
+++ b/handlers/formatting.py
@@ -1,7 +1,7 @@
 from pyrogram import Client, filters
 from pyrogram.types import Message, InlineKeyboardMarkup, InlineKeyboardButton
+from pyrogram.handlers import MessageHandler
 
-@Client.on_message(filters.command("formatting"))
 async def formatting_help(client: Client, message: Message):
     text = """
 **✨ Telegram Message Formatting Guide**
@@ -32,3 +32,7 @@ __Make sure bots are configured to parse Markdown or HTML!__
     )
 
     await message.reply_text(text, reply_markup=buttons, parse_mode="markdown")
+
+
+def register(app: Client) -> None:
+    app.add_handler(MessageHandler(formatting_help, filters.command("formatting")))

--- a/handlers/greetings.py
+++ b/handlers/greetings.py
@@ -1,11 +1,11 @@
 from pyrogram import Client, filters
 from pyrogram.types import Message
+from pyrogram.handlers import MessageHandler
 from utils.decorators import admin_required
 from utils.db import set_chat_setting, get_chat_setting
 
 # --- COMMANDS ---
 
-@Client.on_message(filters.command("setwelcome") & filters.group)
 @admin_required
 async def set_welcome(client: Client, message: Message):
     if len(message.command) < 2:
@@ -15,7 +15,6 @@ async def set_welcome(client: Client, message: Message):
     set_chat_setting(message.chat.id, "welcome", text)
     await message.reply_text("✅ Welcome message set.", parse_mode="markdown")
 
-@Client.on_message(filters.command("setgoodbye") & filters.group)
 @admin_required
 async def set_goodbye(client: Client, message: Message):
     if len(message.command) < 2:
@@ -25,7 +24,6 @@ async def set_goodbye(client: Client, message: Message):
     set_chat_setting(message.chat.id, "goodbye", text)
     await message.reply_text("👋 Goodbye message set.", parse_mode="markdown")
 
-@Client.on_message(filters.command("greetings") & filters.group)
 async def show_greetings(client: Client, message: Message):
     welcome = get_chat_setting(message.chat.id, "welcome", "Not set.")
     goodbye = get_chat_setting(message.chat.id, "goodbye", "Not set.")
@@ -38,7 +36,6 @@ async def show_greetings(client: Client, message: Message):
 
 # --- AUTOMATED HOOKS ---
 
-@Client.on_message(filters.new_chat_members)
 async def greet_new_members(client: Client, message: Message):
     text_template = get_chat_setting(message.chat.id, "welcome")
     if not text_template:
@@ -48,7 +45,6 @@ async def greet_new_members(client: Client, message: Message):
         text = format_greeting(text_template, user, message.chat.title)
         await message.reply_text(text, parse_mode="markdown")
 
-@Client.on_message(filters.left_chat_member)
 async def farewell_user(client: Client, message: Message):
     text_template = get_chat_setting(message.chat.id, "goodbye")
     if not text_template:
@@ -73,3 +69,11 @@ def format_greeting(template: str, user, chat_title: str) -> str:
         id=user.id,
         chat=chat_title,
     )
+
+
+def register(app: Client) -> None:
+    app.add_handler(MessageHandler(set_welcome, filters.command("setwelcome") & filters.group))
+    app.add_handler(MessageHandler(set_goodbye, filters.command("setgoodbye") & filters.group))
+    app.add_handler(MessageHandler(show_greetings, filters.command("greetings") & filters.group))
+    app.add_handler(MessageHandler(greet_new_members, filters.new_chat_members))
+    app.add_handler(MessageHandler(farewell_user, filters.left_chat_member))

--- a/handlers/importexport.py
+++ b/handlers/importexport.py
@@ -1,6 +1,7 @@
 import json
 from pyrogram import Client, filters
 from pyrogram.types import Message, Document
+from pyrogram.handlers import MessageHandler
 from utils.decorators import admin_required
 from utils.db import (
     export_chat_data,
@@ -8,7 +9,6 @@ from utils.db import (
 )
 
 # Export data to JSON and send it as file
-@Client.on_message(filters.command("export") & filters.group)
 @admin_required
 async def export_data(client: Client, message: Message):
     data = await export_chat_data(message.chat.id)
@@ -21,7 +21,6 @@ async def export_data(client: Client, message: Message):
 
 
 # Import JSON data back into current group
-@Client.on_message(filters.command("import") & filters.group)
 @admin_required
 async def import_data(client: Client, message: Message):
     if not message.reply_to_message or not message.reply_to_message.document:
@@ -46,7 +45,6 @@ async def import_data(client: Client, message: Message):
 
 
 # Optional help shortcut
-@Client.on_message(filters.command("importexport") & filters.group)
 async def importexport_help(client: Client, message: Message):
     text = (
         "**📤 Import & Export Help**\n\n"
@@ -55,3 +53,9 @@ async def importexport_help(client: Client, message: Message):
         "_Only group admins can use this. Useful for backups and moving data._"
     )
     await message.reply_text(text, parse_mode="markdown")
+
+
+def register(app: Client) -> None:
+    app.add_handler(MessageHandler(export_data, filters.command("export") & filters.group))
+    app.add_handler(MessageHandler(import_data, filters.command("import") & filters.group))
+    app.add_handler(MessageHandler(importexport_help, filters.command("importexport") & filters.group))

--- a/handlers/languages.py
+++ b/handlers/languages.py
@@ -1,5 +1,6 @@
 from pyrogram import Client, filters
 from pyrogram.types import Message
+from pyrogram.handlers import MessageHandler
 from utils.decorators import admin_required
 from utils.db import get_chat_setting, set_chat_setting
 
@@ -13,7 +14,6 @@ SUPPORTED_LANGUAGES = {
     # Add more as needed
 }
 
-@Client.on_message(filters.command("languages") & filters.group)
 async def show_languages(client: Client, message: Message):
     current = get_chat_setting(message.chat.id, "lang", "en")
     langs = "\n".join(f"• `{code}` - {name}" for code, name in SUPPORTED_LANGUAGES.items())
@@ -24,7 +24,6 @@ async def show_languages(client: Client, message: Message):
         parse_mode="markdown"
     )
 
-@Client.on_message(filters.command("setlang") & filters.group)
 @admin_required
 async def set_language(client: Client, message: Message):
     if len(message.command) < 2:
@@ -38,3 +37,8 @@ async def set_language(client: Client, message: Message):
 
     set_chat_setting(message.chat.id, "lang", code)
     await message.reply_text(f"✅ Language set to `{SUPPORTED_LANGUAGES[code]}`", parse_mode="markdown")
+
+
+def register(app: Client) -> None:
+    app.add_handler(MessageHandler(show_languages, filters.command("languages") & filters.group))
+    app.add_handler(MessageHandler(set_language, filters.command("setlang") & filters.group))

--- a/handlers/logchannel.py
+++ b/handlers/logchannel.py
@@ -1,10 +1,10 @@
 from pyrogram import Client, filters
 from pyrogram.types import Message
+from pyrogram.handlers import MessageHandler
 from utils.decorators import admin_required
 from utils.db import set_chat_setting, get_chat_setting
 from utils.markdown import escape_markdown
 
-@Client.on_message(filters.command("logchannel") & filters.group)
 @admin_required
 async def logchannel_handler(client: Client, message: Message):
     if len(message.command) == 1:
@@ -65,3 +65,7 @@ async def send_log(client: Client, chat_id: int, text: str):
         await client.send_message(log_id, text, parse_mode="markdown")
     except Exception:
         pass
+
+
+def register(app: Client) -> None:
+    app.add_handler(MessageHandler(logchannel_handler, filters.command("logchannel") & filters.group))

--- a/handlers/misc2.py
+++ b/handlers/misc2.py
@@ -5,16 +5,19 @@ import time
 
 # Simple misc commands
 
-@Client.on_message(filters.command("ping"))
 async def ping(client: Client, message: Message):
     start = time.monotonic()
     reply = await message.reply_text("Pong!")
     end = time.monotonic()
     await reply.edit_text(f"Pong! `{(end - start) * 1000:.0f}ms`", parse_mode="markdown")
 
-@Client.on_message(filters.command("echo"))
 async def echo(client: Client, message: Message):
     if len(message.command) < 2:
         await message.reply_text("Usage: `/echo <text>`", parse_mode="markdown")
         return
     await message.reply_text(" ".join(message.command[1:]))
+
+
+def register(app: Client) -> None:
+    app.add_handler(MessageHandler(ping, filters.command("ping")))
+    app.add_handler(MessageHandler(echo, filters.command("echo")))

--- a/handlers/reports.py
+++ b/handlers/reports.py
@@ -1,11 +1,11 @@
 from pyrogram import Client, filters
 from pyrogram.types import Message
+from pyrogram.handlers import MessageHandler
 from utils.db import get_admins
 
 REPORT_TAGS = {"@admin", "/report"}
 
 # Reply-only report handler
-@Client.on_message(filters.group & filters.reply & filters.text & (filters.regex(r"(?i)^@admin$") | filters.command("report")))
 async def handle_report(client: Client, message: Message):
     reported_msg = message.reply_to_message
     reporter = message.from_user
@@ -38,3 +38,10 @@ async def get_admin_ids(client, chat_id):
         return [admin.user.id for admin in admins if not admin.user.is_bot]
     except:
         return []
+
+
+def register(app: Client) -> None:
+    report_filter = filters.group & filters.reply & filters.text & (
+        filters.regex(r"(?i)^@admin$") | filters.command("report")
+    )
+    app.add_handler(MessageHandler(handle_report, report_filter))


### PR DESCRIPTION
## Summary
- refactor handler modules to define explicit `register()` functions
- remove static `Client` decorators and register handlers programmatically

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_687e0085ab98832991d9968a2f204481