### PR TITLE
Make log level configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,4 +6,5 @@ SESSION_NAME=rose_bot
 # Example: -1001234567890 (make sure the bot is in the group)
 LOG_GROUP_ID=-1002867268050
 OWNER_ID=
+LOG_LEVEL=INFO
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains the source code for **Rose**, a modular Telegram bot bu
 - Modular handler architecture
 - SQLite storage
 - Example configuration via `.env.example`
-- Extensive debug logging for easier troubleshooting
+- Configurable log level via `LOG_LEVEL` env var
 
 ## Running locally
 1. Install the requirements:
@@ -22,7 +22,7 @@ This repository contains the source code for **Rose**, a modular Telegram bot bu
    python main.py
    ```
    The bot will exit with an error message if any required credential is missing.
-   All logs are output at the DEBUG level for easy diagnostics.
+   Logging defaults to the INFO level. Set `LOG_LEVEL=DEBUG` for verbose output.
 
 ## Deployment
 Example files are provided for running on container platforms:

--- a/main.py
+++ b/main.py
@@ -13,9 +13,11 @@ from config import LOG_GROUP_ID
 from utils.markdown import escape_markdown
 
 # ------------------- Logging Setup -------------------
+log_level_str = os.environ.get("LOG_LEVEL", "INFO").upper()
+log_level = getattr(logging, log_level_str, logging.INFO)
 logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    level=logging.DEBUG,
+    level=log_level,
 )
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- support `LOG_LEVEL` env var to toggle log verbosity
- document the env var in README
- add `LOG_LEVEL` to `.env.example`

## Testing
- `python -m py_compile $(git ls-files '*.py') && echo "compile done"`

------
https://chatgpt.com/codex/tasks/task_b_687e06f2330c83299b3a477f6505dd25