### PR TITLE
Add wrapper modules for all handlers

### DIFF
--- a/modules/admin.py
+++ b/modules/admin.py
@@ -1,5 +1,5 @@
 from pyrogram import Client
-from handlers.start import register as handler_register
+from handlers.admin import register as handler_register
 
 def register(app: Client) -> None:
     handler_register(app)

--- a/modules/antiflood.py
+++ b/modules/antiflood.py
@@ -1,5 +1,5 @@
 from pyrogram import Client
-from handlers.start import register as handler_register
+from handlers.antiflood import register as handler_register
 
 def register(app: Client) -> None:
     handler_register(app)

--- a/modules/antiraid.py
+++ b/modules/antiraid.py
@@ -1,5 +1,5 @@
 from pyrogram import Client
-from handlers.start import register as handler_register
+from handlers.antiraid import register as handler_register
 
 def register(app: Client) -> None:
     handler_register(app)

--- a/modules/approval.py
+++ b/modules/approval.py
@@ -1,5 +1,5 @@
 from pyrogram import Client
-from handlers.start import register as handler_register
+from handlers.approval import register as handler_register
 
 def register(app: Client) -> None:
     handler_register(app)

--- a/modules/biolink.py
+++ b/modules/biolink.py
@@ -1,5 +1,5 @@
 from pyrogram import Client
-from handlers.start import register as handler_register
+from handlers.biolink import register as handler_register
 
 def register(app: Client) -> None:
     handler_register(app)

--- a/modules/blocklist.py
+++ b/modules/blocklist.py
@@ -1,5 +1,5 @@
 from pyrogram import Client
-from handlers.start import register as handler_register
+from handlers.blocklist import register as handler_register
 
 def register(app: Client) -> None:
     handler_register(app)

--- a/modules/broadcast.py
+++ b/modules/broadcast.py
@@ -1,5 +1,5 @@
 from pyrogram import Client
-from handlers.start import register as handler_register
+from handlers.broadcast import register as handler_register
 
 def register(app: Client) -> None:
     handler_register(app)

--- a/modules/captcha.py
+++ b/modules/captcha.py
@@ -1,5 +1,5 @@
 from pyrogram import Client
-from handlers.start import register as handler_register
+from handlers.captcha import register as handler_register
 
 def register(app: Client) -> None:
     handler_register(app)

--- a/modules/cleancommands.py
+++ b/modules/cleancommands.py
@@ -1,5 +1,5 @@
 from pyrogram import Client
-from handlers.start import register as handler_register
+from handlers.cleancommands import register as handler_register
 
 def register(app: Client) -> None:
     handler_register(app)

--- a/modules/connections.py
+++ b/modules/connections.py
@@ -1,5 +1,5 @@
 from pyrogram import Client
-from handlers.start import register as handler_register
+from handlers.connections import register as handler_register
 
 def register(app: Client) -> None:
     handler_register(app)

--- a/modules/debug_logger.py
+++ b/modules/debug_logger.py
@@ -1,5 +1,5 @@
 from pyrogram import Client
-from handlers.start import register as handler_register
+from handlers.debug_logger import register as handler_register
 
 def register(app: Client) -> None:
     handler_register(app)

--- a/modules/disable.py
+++ b/modules/disable.py
@@ -1,5 +1,5 @@
 from pyrogram import Client
-from handlers.start import register as handler_register
+from handlers.disable import register as handler_register
 
 def register(app: Client) -> None:
     handler_register(app)

--- a/modules/federations.py
+++ b/modules/federations.py
@@ -1,5 +1,5 @@
 from pyrogram import Client
-from handlers.start import register as handler_register
+from handlers.federations import register as handler_register
 
 def register(app: Client) -> None:
     handler_register(app)

--- a/modules/filters.py
+++ b/modules/filters.py
@@ -1,5 +1,5 @@
 from pyrogram import Client
-from handlers.start import register as handler_register
+from handlers.filters import register as handler_register
 
 def register(app: Client) -> None:
     handler_register(app)

--- a/modules/formatting.py
+++ b/modules/formatting.py
@@ -1,5 +1,5 @@
 from pyrogram import Client
-from handlers.start import register as handler_register
+from handlers.formatting import register as handler_register
 
 def register(app: Client) -> None:
     handler_register(app)

--- a/modules/greetings.py
+++ b/modules/greetings.py
@@ -1,5 +1,5 @@
 from pyrogram import Client
-from handlers.start import register as handler_register
+from handlers.greetings import register as handler_register
 
 def register(app: Client) -> None:
     handler_register(app)

--- a/modules/group.py
+++ b/modules/group.py
@@ -1,5 +1,5 @@
 from pyrogram import Client
-from handlers.start import register as handler_register
+from handlers.group import register as handler_register
 
 def register(app: Client) -> None:
     handler_register(app)

--- a/modules/help.py
+++ b/modules/help.py
@@ -1,11 +1,7 @@
 from pyrogram import Client, filters
 from pyrogram.handlers import MessageHandler
-from pyrogram.types import Message
-
-HELP_TEXT = "This is the help message from modules.help."
-
-async def help_cmd(client: Client, message: Message):
-    await message.reply_text(HELP_TEXT)
+from handlers.start import help_cmd
 
 def register(app: Client) -> None:
+    """Register the /help command using the default handler."""
     app.add_handler(MessageHandler(help_cmd, filters.command("help")))

--- a/modules/importexport.py
+++ b/modules/importexport.py
@@ -1,5 +1,5 @@
 from pyrogram import Client
-from handlers.start import register as handler_register
+from handlers.importexport import register as handler_register
 
 def register(app: Client) -> None:
     handler_register(app)

--- a/modules/languages.py
+++ b/modules/languages.py
@@ -1,5 +1,5 @@
 from pyrogram import Client
-from handlers.start import register as handler_register
+from handlers.languages import register as handler_register
 
 def register(app: Client) -> None:
     handler_register(app)

--- a/modules/locks.py
+++ b/modules/locks.py
@@ -1,5 +1,5 @@
 from pyrogram import Client
-from handlers.start import register as handler_register
+from handlers.locks import register as handler_register
 
 def register(app: Client) -> None:
     handler_register(app)

--- a/modules/logchannel.py
+++ b/modules/logchannel.py
@@ -1,5 +1,5 @@
 from pyrogram import Client
-from handlers.start import register as handler_register
+from handlers.logchannel import register as handler_register
 
 def register(app: Client) -> None:
     handler_register(app)

--- a/modules/misc.py
+++ b/modules/misc.py
@@ -1,5 +1,5 @@
 from pyrogram import Client
-from handlers.start import register as handler_register
+from handlers.misc import register as handler_register
 
 def register(app: Client) -> None:
     handler_register(app)

--- a/modules/misc2.py
+++ b/modules/misc2.py
@@ -1,5 +1,5 @@
 from pyrogram import Client
-from handlers.start import register as handler_register
+from handlers.misc2 import register as handler_register
 
 def register(app: Client) -> None:
     handler_register(app)

--- a/modules/notes.py
+++ b/modules/notes.py
@@ -1,5 +1,5 @@
 from pyrogram import Client
-from handlers.start import register as handler_register
+from handlers.notes import register as handler_register
 
 def register(app: Client) -> None:
     handler_register(app)

--- a/modules/pin.py
+++ b/modules/pin.py
@@ -1,5 +1,5 @@
 from pyrogram import Client
-from handlers.start import register as handler_register
+from handlers.pin import register as handler_register
 
 def register(app: Client) -> None:
     handler_register(app)

--- a/modules/privacy.py
+++ b/modules/privacy.py
@@ -1,5 +1,5 @@
 from pyrogram import Client
-from handlers.start import register as handler_register
+from handlers.privacy import register as handler_register
 
 def register(app: Client) -> None:
     handler_register(app)

--- a/modules/purge.py
+++ b/modules/purge.py
@@ -1,5 +1,5 @@
 from pyrogram import Client
-from handlers.start import register as handler_register
+from handlers.purge import register as handler_register
 
 def register(app: Client) -> None:
     handler_register(app)

--- a/modules/reports.py
+++ b/modules/reports.py
@@ -1,5 +1,5 @@
 from pyrogram import Client
-from handlers.start import register as handler_register
+from handlers.reports import register as handler_register
 
 def register(app: Client) -> None:
     handler_register(app)

--- a/modules/rules.py
+++ b/modules/rules.py
@@ -1,5 +1,5 @@
 from pyrogram import Client
-from handlers.start import register as handler_register
+from handlers.rules import register as handler_register
 
 def register(app: Client) -> None:
     handler_register(app)

--- a/modules/topics.py
+++ b/modules/topics.py
@@ -1,5 +1,5 @@
 from pyrogram import Client
-from handlers.start import register as handler_register
+from handlers.topics import register as handler_register
 
 def register(app: Client) -> None:
     handler_register(app)

--- a/modules/warnings.py
+++ b/modules/warnings.py
@@ -1,5 +1,5 @@
 from pyrogram import Client
-from handlers.start import register as handler_register
+from handlers.warnings import register as handler_register
 
 def register(app: Client) -> None:
     handler_register(app)


### PR DESCRIPTION
## Summary
- add wrapper modules that call each handler's `register` function
- route `/help` via a module that reuses the handler implementation

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_687f6771923c8329b83b1034fac4f43e