### PR TITLE
Switch help module to handler-based register

### DIFF
--- a/handlers/help_command.py
+++ b/handlers/help_command.py
@@ -1,0 +1,9 @@
+from pyrogram import Client, filters
+from pyrogram.handlers import MessageHandler
+
+from .start import help_cmd
+
+
+def register(app: Client) -> None:
+    """Register the /help command."""
+    app.add_handler(MessageHandler(help_cmd, filters.command("help")))

--- a/modules/help.py
+++ b/modules/help.py
@@ -1,7 +1,10 @@
-from pyrogram import Client, filters
-from pyrogram.handlers import MessageHandler
-from handlers.start import help_cmd
+"""Module wrapper for /help command registration."""
+
+from pyrogram import Client
+
+from handlers.help_command import register as handler_register
+
 
 def register(app: Client) -> None:
-    """Register the /help command using the default handler."""
-    app.add_handler(MessageHandler(help_cmd, filters.command("help")))
+    """Delegate registration to ``handlers.help_command``."""
+    handler_register(app)


### PR DESCRIPTION
## Summary
- refactor `modules/help.py` to delegate registration
- add new handler `handlers/help_command.py` that registers the `/help` command

## Testing
- `python -m py_compile modules/*.py handlers/*.py main.py`

------
https://chatgpt.com/codex/tasks/task_b_687f6bbeba648329b05fe7df88911cb7