### PR TITLE
Fix load_handlers reference

### DIFF
--- a/main.py
+++ b/main.py
@@ -144,7 +144,7 @@ async def main() -> None:
     app.add_handler(CallbackQueryHandler(_log_query), group=-2)
 
     await load_modules(app)
-    await load_handlers(app)
+    await register_handlers(app)
 
     LOGGER.info("Bot started. Press Ctrl+C to stop.")
     await idle()


### PR DESCRIPTION
## Summary
- register handlers using the exported helper

## Testing
- `python -m py_compile main.py`
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_687f6cac9c1c8329859e408e3b02e8ea