### PR TITLE
Add placeholder register to help handler

### DIFF
--- a/handlers/help.py
+++ b/handlers/help.py
@@ -71,3 +71,12 @@ HELP_MODULES = {
 }
 
 # The actual /help command logic is now implemented in ``handlers.start``.
+
+from pyrogram import Client
+
+
+def register(app: Client) -> None:
+    """Placeholder to satisfy the handler loader."""
+    # This module only provides help text used by ``handlers.start`` and
+    # doesn't need to register any handlers itself.
+    return None


### PR DESCRIPTION
## Summary
- ensure every handler has a `register(app)` method by adding one to `help.py`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_687fbc5db9308329b82f40e9b0e77ff2