### PR TITLE
Fix filter command conflict

### DIFF
--- a/handlers/filters.py
+++ b/handlers/filters.py
@@ -53,7 +53,7 @@ async def stopall_cmd(client: Client, message: Message):
 
 
 async def filter_worker(client: Client, message: Message):
-    if not message.text:
+    if not message.text or message.text.startswith("/"):
         return
 
     text = message.text.lower()


### PR DESCRIPTION
## Summary
- avoid triggering filters on commands

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687fbd0ff57083299dcfe9dfc9eaf995