### PR TITLE
Fix Pyrogram plugin loading and add test handlers

### DIFF
--- a/plugins/test.py
+++ b/plugins/test.py
@@ -1,0 +1,14 @@
+from pyrogram import Client, filters
+from pyrogram.types import Message
+
+@Client.on_message(filters.command("ping"))
+async def ping_pong(client: Client, message: Message):
+    await message.reply_text("pong")
+
+@Client.on_message(filters.command("start"))
+async def start_message(client: Client, message: Message):
+    await message.reply_text("Hello, I am alive!")
+
+@Client.on_message(filters.text & ~filters.command(["ping", "start"]))
+async def echo_all(client: Client, message: Message):
+    await message.reply_text(f"echo: {message.text}")


### PR DESCRIPTION
## Summary
- switch log level to debug
- load plugins from absolute path and log results
- add simple test plugin for /start and /ping

## Testing
- `python -m py_compile main.py plugins/test.py`

------
https://chatgpt.com/codex/tasks/task_b_687fd9239a5c8329bc6bb0b4fadbdfd4