### PR TITLE
Fix plugin loader path

### DIFF
--- a/main.py
+++ b/main.py
@@ -58,7 +58,8 @@ except ValueError:
 # -------------------------------------------------------------
 # Bot Client
 # -------------------------------------------------------------
-plugins_root = Path(__file__).resolve().parent / "plugins"
+plugins_root = "plugins"  # package-style path used by Pyrogram
+PLUGINS_DIR = Path(__file__).resolve().parent / plugins_root
 app = Client(
     SESSION_NAME,
     api_id=API_ID,
@@ -73,7 +74,7 @@ def load_plugins() -> None:
     app.plugins = {"root": str(plugins_root)}
     app.load_plugins()
     total = sum(len(g) for g in app.dispatcher.groups.values())
-    LOGGER.info("Loaded %d handlers from %s", total, plugins_root)
+    LOGGER.info("Loaded %d handlers from %s", total, PLUGINS_DIR)
     app.plugins = None
 
 # -------------------------------------------------------------


### PR DESCRIPTION
## Summary
- fix module loading error by providing a relative plugins path
- log loaded plugins using an absolute path

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py 2>err.log` *(fails: ConnectionError to Telegram)*

------
https://chatgpt.com/codex/tasks/task_b_687fdb6597c48329842bca794b2dc8a4