### PR TITLE
Ensure all plugins expose register function

### DIFF
--- a/plugins/help.py
+++ b/plugins/help.py
@@ -21,3 +21,8 @@ HELP_MODULES = {
     'pinline': 'Pin messages with an inline button.',
     'reports': 'Report messages to admins.',
 }
+
+
+def register(app) -> None:
+    """This module only provides HELP_MODULES and registers no handlers."""
+    pass

--- a/plugins/help_command.py
+++ b/plugins/help_command.py
@@ -1,3 +1,12 @@
+"""Register the `/help` command handler."""
+
 from pyrogram import Client, filters
 from pyrogram.handlers import MessageHandler
+
 from .start import help_cmd
+
+
+def register(app: Client) -> None:
+    """Attach the help command handler to the given app."""
+    app.add_handler(MessageHandler(help_cmd, filters.command("help")), group=0)
+


### PR DESCRIPTION
## Summary
- add helper register to help_command
- ensure help.py defines register so plugin loader won't warn

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_688126363ce883299ee2507052448cde