### PR TITLE
Enhance startup logging and debugging

### DIFF
--- a/render-worker.yaml
+++ b/render-worker.yaml
@@ -19,6 +19,8 @@ services:
         value: YOUR_API_HASH
       - key: BOT_TOKEN
         value: YOUR_BOT_TOKEN
+      - key: USE_WEBHOOK
+        value: "false"
 
   # Optional: run as a web service with a health check instead of a worker.
   # Uncomment below to deploy a minimal web server that keeps the service alive.


### PR DESCRIPTION
## Summary
- improve startup routine
- add a `RawUpdateHandler` for verbose logging of all updates
- log more info when starting the bot
- show how to disable webhook in `render-worker.yaml`

## Testing
- `pip install -r requirements.txt -q`
- `python -m py_compile main.py web.py plugins/start.py`

------
https://chatgpt.com/codex/tasks/task_b_6883a1428d9083298e7d8efe5082b751