### PR TITLE
Fix Pyrogram handlers and debugging

### DIFF
--- a/plugins/test.py
+++ b/plugins/test.py
@@ -1,13 +1,17 @@
 from pyrogram import Client, filters
 from pyrogram.types import Message
 from pyrogram.handlers import MessageHandler
+from utils.errors import catch_errors
 
+@catch_errors
 async def ping_pong(client: Client, message: Message):
     await message.reply_text("pong")
 
+@catch_errors
 async def start_message(client: Client, message: Message):
     await message.reply_text("Hello, I am alive!")
 
+@catch_errors
 async def echo_all(client: Client, message: Message):
     await message.reply_text(f"echo: {message.text}")
 


### PR DESCRIPTION
## Summary
- log and wrap handlers when registering on Pyrogram client
- allow command prefixes `/`, `!` and `.`
- register a debug handler and use error catching in `plugins/test.py`

## Testing
- `python -m py_compile main.py plugins/test.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6883acb7c6608329bf19f9e82386d1ab