### PR TITLE
Fix Render deploy modes and logging

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,4 +9,5 @@ dependencies:
       - aiosqlite
       - motor
       - python-dotenv
-      - flask
+      - fastapi
+      - uvicorn

--- a/plugins/help_command.py
+++ b/plugins/help_command.py
@@ -3,10 +3,13 @@
 from pyrogram import Client, filters
 from pyrogram.handlers import MessageHandler
 
-from .start import help_cmd
+from .start import help_cmd, PREFIXES
 
 
 def register(app: Client) -> None:
     """Attach the help command handler to the given app."""
-    app.add_handler(MessageHandler(help_cmd, filters.command("help")), group=0)
+    app.add_handler(
+        MessageHandler(help_cmd, filters.command("help", prefixes=PREFIXES)),
+        group=0,
+    )
 

--- a/plugins/start.py
+++ b/plugins/start.py
@@ -18,6 +18,8 @@ from modules.buttons import (
 )
 import logging
 
+PREFIXES = ["/", "!", "."]
+
 LOGGER = logging.getLogger(__name__)
 
 MODULE_BUTTONS = [
@@ -139,10 +141,22 @@ async def help_cb(client: Client, query: CallbackQuery):
 
 
 def register(app):
-    app.add_handler(MessageHandler(start_cmd, filters.command('start')), group=0)
-    app.add_handler(MessageHandler(menu_cmd, filters.command('menu')), group=0)
-    app.add_handler(MessageHandler(help_cmd, filters.command('help')), group=0)
-    app.add_handler(MessageHandler(test_cmd, filters.command('test')), group=0)
+    app.add_handler(
+        MessageHandler(start_cmd, filters.command("start", prefixes=PREFIXES)),
+        group=0,
+    )
+    app.add_handler(
+        MessageHandler(menu_cmd, filters.command("menu", prefixes=PREFIXES)),
+        group=0,
+    )
+    app.add_handler(
+        MessageHandler(help_cmd, filters.command("help", prefixes=PREFIXES)),
+        group=0,
+    )
+    app.add_handler(
+        MessageHandler(test_cmd, filters.command("test", prefixes=PREFIXES)),
+        group=0,
+    )
     app.add_handler(CallbackQueryHandler(menu_open_cb, filters.regex('^menu:open$')), group=0)
     app.add_handler(CallbackQueryHandler(panel_open_cb, filters.regex('^(?!menu)[a-z]+:open$')), group=0)
     app.add_handler(CallbackQueryHandler(menu_cb, filters.regex('^main:menu$')), group=0)

--- a/render-webhook.yaml
+++ b/render-webhook.yaml
@@ -12,7 +12,9 @@ services:
         value: YOUR_API_HASH
       - key: BOT_TOKEN
         value: YOUR_BOT_TOKEN
-      - key: USE_WEBHOOK
-        value: "true"
+      - key: DEPLOY_MODE
+        value: webhook
       - key: WEBHOOK_URL
         value: https://example.com/webhook
+      - key: PORT
+        value: "10000"

--- a/render-worker.yaml
+++ b/render-worker.yaml
@@ -19,8 +19,8 @@ services:
         value: YOUR_API_HASH
       - key: BOT_TOKEN
         value: YOUR_BOT_TOKEN
-      - key: USE_WEBHOOK
-        value: "false"
+      - key: DEPLOY_MODE
+        value: worker
 
   # Optional: run as a web service with a health check instead of a worker.
   # Uncomment below to deploy a minimal web server that keeps the service alive.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ tgcrypto==1.2.5
 aiosqlite==0.19.0
 motor==3.3.1
 python-dotenv==1.0.1
-flask==3.0.0
+fastapi==0.109.0
+uvicorn==0.25.0


### PR DESCRIPTION
## Summary
- add `DEPLOY_MODE` env var for worker/webhook operation
- add FastAPI webhook server and support for webhook mode
- update command handler prefixes
- add global debug logger
- document Render configs for both modes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6883b3f1e7f48329aa0bea3a64b571aa