### PR TITLE
Improve deploy options and docs for Rose bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,18 @@ This repository contains the source code for **Rose**, a modular Telegram bot bu
    ```bash
    python main.py
    ```
-   The bot will exit with an error message if any required credential is missing.
-   All logs are output at the DEBUG level for easy diagnostics.
+    The bot will exit with an error message if any required credential is missing.
+    All logs are output at the DEBUG level for easy diagnostics.
+
+Set `DEPLOY_MODE=worker` to run the bot with long polling. For webhook mode
+(`DEPLOY_MODE=webhook`), also set `WEBHOOK_URL` and `PORT` so the FastAPI
+server can listen on `0.0.0.0:10000` and Telegram can reach your endpoint.
 
 ## Deployment
 Example files are provided for running on container platforms:
 - `Dockerfile` for Docker based deployments
-- `Procfile` and `render-worker.yaml`/`render-web.yaml` for hosting services
+- `Procfile` for Heroku style platforms
+- `render.yaml` includes both worker and webhook services for Render
 
 ---
 Licensed under the MIT License.

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,36 @@
+services:
+  - type: worker
+    name: rose-bot-worker
+    env: python
+    plan: free
+    buildCommand: pip install -r requirements.txt
+    startCommand: sh start.sh
+    envVars:
+      - key: API_ID
+        value: YOUR_API_ID
+      - key: API_HASH
+        value: YOUR_API_HASH
+      - key: BOT_TOKEN
+        value: YOUR_BOT_TOKEN
+      - key: DEPLOY_MODE
+        value: worker
+
+  - type: web
+    name: rose-bot-webhook
+    env: python
+    plan: free
+    buildCommand: pip install -r requirements.txt
+    startCommand: python main.py
+    envVars:
+      - key: API_ID
+        value: YOUR_API_ID
+      - key: API_HASH
+        value: YOUR_API_HASH
+      - key: BOT_TOKEN
+        value: YOUR_BOT_TOKEN
+      - key: DEPLOY_MODE
+        value: webhook
+      - key: WEBHOOK_URL
+        value: https://example.com/webhook
+      - key: PORT
+        value: "10000"


### PR DESCRIPTION
## Summary
- add combined Render config for worker and webhook services
- document deploy modes and Render YAML in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6883b694cf6c832991c025d655652ab0