### PR TITLE
Improve Render support and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,18 @@ This repository contains the source code for **Rose**, a modular Telegram bot bu
     The bot will exit with an error message if any required credential is missing.
     All logs are output at the DEBUG level for easy diagnostics.
 
-Set `DEPLOY_MODE=worker` to run the bot with long polling. For webhook mode
-(`DEPLOY_MODE=webhook`), also set `WEBHOOK_URL` and `PORT` so the FastAPI
-server can listen on `0.0.0.0:10000` and Telegram can reach your endpoint.
+Set `DEPLOY_MODE=worker` to run the bot with long polling. When deploying as a
+web service you can use `DEPLOY_MODE=webhook` together with `WEBHOOK_URL` and
+`PORT` so the FastAPI server listens on `0.0.0.0:$PORT` and Telegram can reach
+your endpoint.
 
 ## Deployment
 Example files are provided for running on container platforms:
 - `Dockerfile` for Docker based deployments
 - `Procfile` for Heroku style platforms
-- `render.yaml` includes both worker and webhook services for Render
+- `render.yaml` for a combined worker/webhook setup on Render
+- `render-worker.yaml` and `render-webhook.yaml` demonstrate separate services
+  for long polling and webhook modes on Render
 
 ---
 Licensed under the MIT License.

--- a/plugins/start.py
+++ b/plugins/start.py
@@ -7,6 +7,7 @@ from pyrogram.types import (
 )
 from pyrogram.handlers import MessageHandler, CallbackQueryHandler
 from .help import HELP_MODULES
+from utils.errors import catch_errors
 from modules.buttons import (
     admin_panel,
     approvals_panel,
@@ -67,6 +68,7 @@ def help_menu() -> InlineKeyboardMarkup:
     keys.append([InlineKeyboardButton('❌ Close', callback_data='help:close')])
     return InlineKeyboardMarkup(keys)
 
+@catch_errors
 async def start_cmd(client: Client, message: Message):
     LOGGER.debug('📩 /start received')
     text = '**Thanks for adding me!**\nUse /menu to configure moderation.' if message.chat.type in ['group', 'supergroup'] else '**🌹 Rose Bot**\nI help moderate and protect your group.'
@@ -79,12 +81,14 @@ async def start_cmd(client: Client, message: Message):
         parse_mode="markdown",
     )
 
+@catch_errors
 async def menu_cmd(client: Client, message: Message):
     LOGGER.debug('📩 /menu received')
     await message.reply_text(
         '**📋 Control Panel**', reply_markup=build_menu(), quote=True, parse_mode="markdown"
     )
 
+@catch_errors
 async def help_cmd(client: Client, message: Message):
     LOGGER.debug('📩 /help received')
     if len(message.command) > 1:
@@ -96,6 +100,7 @@ async def help_cmd(client: Client, message: Message):
         return
     await message.reply_text('**🛠 Help Panel**\nClick a button below to view module commands:', reply_markup=help_menu(), parse_mode='markdown')
 
+@catch_errors
 async def test_cmd(client: Client, message: Message):
     LOGGER.debug('📩 /test received')
     await message.reply_text('✅ Test command received!')


### PR DESCRIPTION
## Summary
- add global loop exception handler and message logger
- decorate start module commands with catch_errors
- document worker vs webhook usage

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `API_ID=123 API_HASH=123 BOT_TOKEN=123 DEPLOY_MODE=worker python main.py` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_6883ba95d14083298eb4b8d9012034da