### PR TITLE
Fix worker deployment and add docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ web service you can use `DEPLOY_MODE=webhook` together with `WEBHOOK_URL` and
 `PORT` so the FastAPI server listens on `0.0.0.0:$PORT` and Telegram can reach
 your endpoint.
 
+When deploying to **Render**, make sure the service is a **worker** so the bot
+polls Telegram for updates. The provided `render-worker.yaml` blueprint sets the
+correct command and environment variables out of the box.
+
 ## Deployment
 Example files are provided for running on container platforms:
 - `Dockerfile` for Docker based deployments

--- a/start.sh
+++ b/start.sh
@@ -6,4 +6,7 @@ if [ -d "venv" ]; then
   source venv/bin/activate
 fi
 
+# Ensure DEPLOY_MODE defaults to worker so long polling works on services like Render
+export DEPLOY_MODE="${DEPLOY_MODE:-worker}"
+
 exec python -u main.py


### PR DESCRIPTION
## Summary
- ensure `DEPLOY_MODE` defaults to `worker` in start script
- update README with Render worker instructions

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6883c1099a048329b8e29e630b47a25f