### PR TITLE
Fix bot logging and handler replies

### DIFF
--- a/plugins/misc2.py
+++ b/plugins/misc2.py
@@ -6,9 +6,21 @@ import time
 
 async def ping(client: Client, message: Message):
     start = time.monotonic()
-    reply = await message.reply_text('Pong!')
-    end = time.monotonic()
-    await reply.edit_text(f'Pong! `{(end - start) * 1000:.0f}ms`', parse_mode='markdown')
+    if message.chat.type == 'private':
+        reply = await message.reply_text('Pong!')
+        end = time.monotonic()
+        await reply.edit_text(f'Pong! `{(end - start) * 1000:.0f}ms`', parse_mode='markdown')
+    else:
+        await message.reply("📩 Pong sent in PM.")
+        end = time.monotonic()
+        try:
+            await client.send_message(
+                message.from_user.id,
+                f'Pong! `{(end - start) * 1000:.0f}ms`',
+                parse_mode='markdown',
+            )
+        except Exception:
+            await message.reply("❌ I can't message you. Please start me in PM first.")
 
 async def echo(client: Client, message: Message):
     if len(message.command) < 2:

--- a/plugins/start.py
+++ b/plugins/start.py
@@ -71,15 +71,34 @@ def help_menu() -> InlineKeyboardMarkup:
 @catch_errors
 async def start_cmd(client: Client, message: Message):
     LOGGER.debug('📩 /start received')
-    text = '**Thanks for adding me!**\nUse /menu to configure moderation.' if message.chat.type in ['group', 'supergroup'] else '**🌹 Rose Bot**\nI help moderate and protect your group.'
-    await message.reply_text(
-        text,
-        reply_markup=InlineKeyboardMarkup(
-            [[InlineKeyboardButton('📋 Menu', callback_data='menu:open')]]
-        ),
-        quote=True,
-        parse_mode="markdown",
+    text = (
+        '**Thanks for adding me!**\nUse /menu to configure moderation.'
+        if message.chat.type in ['group', 'supergroup']
+        else '**🌹 Rose Bot**\nI help moderate and protect your group.'
     )
+
+    if message.chat.type == 'private':
+        await message.reply_text(
+            text,
+            reply_markup=InlineKeyboardMarkup(
+                [[InlineKeyboardButton('📋 Menu', callback_data='menu:open')]]
+            ),
+            quote=True,
+            parse_mode="markdown",
+        )
+    else:
+        await message.reply("📩 I've sent you a PM with information.")
+        try:
+            await client.send_message(
+                message.from_user.id,
+                text,
+                reply_markup=InlineKeyboardMarkup(
+                    [[InlineKeyboardButton('📋 Menu', callback_data='menu:open')]]
+                ),
+                parse_mode="markdown",
+            )
+        except Exception:
+            await message.reply("❌ I can't message you. Please start me in PM first.")
 
 @catch_errors
 async def menu_cmd(client: Client, message: Message):
@@ -93,17 +112,39 @@ async def help_cmd(client: Client, message: Message):
     LOGGER.debug('📩 /help received')
     if len(message.command) > 1:
         mod = message.command[1].lower()
-        if mod in HELP_MODULES:
-            await message.reply_text(HELP_MODULES[mod], reply_markup=help_menu(), parse_mode='markdown')
-        else:
-            await message.reply_text('❌ Unknown module.\nUse `/help` to see available modules.', parse_mode='markdown')
-        return
-    await message.reply_text('**🛠 Help Panel**\nClick a button below to view module commands:', reply_markup=help_menu(), parse_mode='markdown')
+        response = (
+            HELP_MODULES[mod]
+            if mod in HELP_MODULES
+            else '❌ Unknown module.\nUse `/help` to see available modules.'
+        )
+    else:
+        response = '**🛠 Help Panel**\nClick a button below to view module commands:'
+
+    if message.chat.type == 'private':
+        await message.reply_text(response, reply_markup=help_menu(), parse_mode='markdown')
+    else:
+        await message.reply("📩 I've sent you a PM with help information.")
+        try:
+            await client.send_message(
+                message.from_user.id,
+                response,
+                reply_markup=help_menu(),
+                parse_mode='markdown',
+            )
+        except Exception:
+            await message.reply("❌ I can't message you. Please start me in PM first.")
 
 @catch_errors
 async def test_cmd(client: Client, message: Message):
     LOGGER.debug('📩 /test received')
-    await message.reply_text('✅ Test command received!')
+    if message.chat.type == 'private':
+        await message.reply_text('✅ Test command received!')
+    else:
+        await message.reply("📩 Check your PM for the test result.")
+        try:
+            await client.send_message(message.from_user.id, '✅ Test command received!')
+        except Exception:
+            await message.reply("❌ I can't message you. Please start me in PM first.")
 
 async def menu_open_cb(client: Client, query: CallbackQuery):
     LOGGER.debug('🟢 menu:open callback')

--- a/plugins/test.py
+++ b/plugins/test.py
@@ -7,12 +7,26 @@ from utils.errors import catch_errors
 
 @catch_errors
 async def ping_pong(client: Client, message: Message):
-    await message.reply_text("pong")
+    if message.chat.type == 'private':
+        await message.reply_text("pong")
+    else:
+        await message.reply("📩 Pong sent in PM.")
+        try:
+            await client.send_message(message.from_user.id, "pong")
+        except Exception:
+            await message.reply("❌ I can't message you. Please start me in PM first.")
 
 
 @catch_errors
 async def start_message(client: Client, message: Message):
-    await message.reply_text("Hello, I am alive!")
+    if message.chat.type == 'private':
+        await message.reply_text("Hello, I am alive!")
+    else:
+        await message.reply("📩 I've messaged you privately.")
+        try:
+            await client.send_message(message.from_user.id, "Hello, I am alive!")
+        except Exception:
+            await message.reply("❌ I can't message you. Please start me in PM first.")
 
 
 @catch_errors

--- a/utils/errors.py
+++ b/utils/errors.py
@@ -12,11 +12,23 @@ def catch_errors(func):
         try:
             return await func(*args, **kwargs)
         except Exception as e:
+            # Log the exception without triggering recursion issues
             try:
-                logger.exception("Unhandled exception in handler %s: %s", func.__name__, e)
+                logger.exception(
+                    "Unhandled exception in handler %s: %s",
+                    func.__name__,
+                    e,
+                )
             except Exception:
+                # Fallback to stderr if logging fails for some reason
                 print(f"Logging failed for {func.__name__}: {e}", file=sys.stderr)
+
+            # Attempt to notify the user about the failure
             if args and isinstance(args[-1], Message):
                 with suppress(Exception):
                     await args[-1].reply_text("⚠️ An unexpected error occurred.")
+
+            # Re-raise so outer wrappers or the event loop can handle it
+            raise
+
     return wrapper


### PR DESCRIPTION
## Summary
- add `_debug_message` logger and ignore self messages in logging
- rework `/start`, `/help`, `/test`, `/ping` handlers to reply privately when used in groups
- improve `catch_errors` decorator to re-raise exceptions

## Testing
- `python -m py_compile utils/errors.py plugins/start.py plugins/test.py plugins/misc2.py main.py`
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from plugins import register_all
class Dummy:
    def add_handler(self,*a,**k):
        pass
print('loaded:', register_all(Dummy()))
PY`

------
https://chatgpt.com/codex/tasks/task_b_68855249221883298617c2fe4ba6000d