### PR TITLE
Fix plugin handlers recursion bug

### DIFF
--- a/main.py
+++ b/main.py
@@ -87,9 +87,11 @@ class RoseClient(Client):
         if name in {"log_all_messages", "_debug_query", "_debug_raw"}:
             return super().add_handler(handler, group)
 
+        orig_callback = handler.callback
+
         async def wrapped(client, *args, **kwargs):
             try:
-                await handler.callback(client, *args, **kwargs)
+                await orig_callback(client, *args, **kwargs)
             except RecursionError as e:
                 print(f"RecursionError in handler {name}: {e}", file=sys.stderr)
             except Exception as e:


### PR DESCRIPTION
## Summary
- fix recursion bug in `add_handler`

## Testing
- `python -m py_compile main.py plugins/*.py modules/**/*.py db/*.py utils/*.py web.py`
- `python -m unittest`

------
https://chatgpt.com/codex/tasks/task_b_6885c4f4a0188329b6d021c5fca6bd0f