### PR TITLE
Fix handler count logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -154,7 +154,13 @@ async def _set_webhook(client: Client) -> None:
 # Main
 # -------------------------------------------------------------
 async def _startup() -> None:
+    # Ensure handler registration tasks run on the current loop
+    app.loop = asyncio.get_running_loop()
+    app.dispatcher.loop = app.loop
     plugin_count = register_all(app)
+    # Allow dispatcher tasks scheduled by add_handler() to run so
+    # app.dispatcher.groups gets populated before we count handlers
+    await asyncio.sleep(0)
     LOGGER.debug("📚 Initializing database...")
     await init_db()
     LOGGER.info("✅ Database ready")


### PR DESCRIPTION
## Summary
- set `app.dispatcher.loop` to the running loop so handler registration tasks execute
- yield to the event loop before counting registered handlers

## Testing
- `python - <<'EOF'
import os, asyncio
os.environ['API_ID']='1'
os.environ['API_HASH']='hash'
os.environ['BOT_TOKEN']='token'
import main
asyncio.run(main._startup())
EOF`

------
https://chatgpt.com/codex/tasks/task_b_6887a483c9b08329b5376018200b1876