### PR TITLE
Fix parse_mode usage

### DIFF
--- a/plugins/admin.py
+++ b/plugins/admin.py
@@ -1,4 +1,5 @@
 from pyrogram import Client, filters
+from pyrogram.enums import ParseMode
 from modules.constants import PREFIXES
 from pyrogram.types import Message, CallbackQuery
 from pyrogram.handlers import MessageHandler, CallbackQueryHandler
@@ -52,7 +53,7 @@ async def anonadmin(client: Client, message: Message):
         return
     value = args[1].lower()
     if value not in ['on', 'off']:
-        await message.reply_text('Usage: `/anonadmin on|off`', parse_mode='markdown')
+        await message.reply_text('Usage: `/anonadmin on|off`', parse_mode=ParseMode.MARKDOWN)
         return
     set_chat_setting(message.chat.id, 'anonadmin', value)
     await message.reply_text(f'✅ Anon admin setting updated to `{value}`.')
@@ -66,14 +67,14 @@ async def adminerror(client: Client, message: Message):
         return
     value = args[1].lower()
     if value not in ['on', 'off']:
-        await message.reply_text('Usage: `/adminerror on|off`', parse_mode='markdown')
+        await message.reply_text('Usage: `/adminerror on|off`', parse_mode=ParseMode.MARKDOWN)
         return
     set_chat_setting(message.chat.id, 'adminerror', value)
     await message.reply_text(f'✅ Admin error setting updated to `{value}`.')
 
 @is_admin
 async def admin_menu(client: Client, message: Message):
-    await message.reply_text('**🛠 Admin Panel**\nChoose what you want to manage:', reply_markup=admin_panel(), parse_mode='markdown')
+    await message.reply_text('**🛠 Admin Panel**\nChoose what you want to manage:', reply_markup=admin_panel(), parse_mode=ParseMode.MARKDOWN)
 
 async def admin_cb(client: Client, query: CallbackQuery):
     data = query.data.split(':')[1]
@@ -85,7 +86,7 @@ async def admin_cb(client: Client, query: CallbackQuery):
         text = 'Use /adminlist to see all admins.'
     else:
         text = 'Unknown command.'
-    await query.message.edit_text(text, reply_markup=admin_panel(), parse_mode='markdown')
+    await query.message.edit_text(text, reply_markup=admin_panel(), parse_mode=ParseMode.MARKDOWN)
     await query.answer()
 
 

--- a/plugins/antiraid.py
+++ b/plugins/antiraid.py
@@ -1,4 +1,5 @@
 from pyrogram import Client, filters
+from pyrogram.enums import ParseMode
 from modules.constants import PREFIXES
 from pyrogram.types import Message
 from pyrogram.handlers import MessageHandler
@@ -17,7 +18,7 @@ async def toggle_antiraid(client: Client, message: Message):
         return
     status = args[1].lower()
     if status not in ['on', 'off']:
-        await message.reply_text('Usage: `/antiraid on|off`', parse_mode='markdown')
+        await message.reply_text('Usage: `/antiraid on|off`', parse_mode=ParseMode.MARKDOWN)
         return
     ANTIRAID_STATUS[message.chat.id] = status
     await message.reply_text(f'✅ Antiraid mode set to `{status}`.')

--- a/plugins/approval.py
+++ b/plugins/approval.py
@@ -1,4 +1,5 @@
 from pyrogram import Client, filters
+from pyrogram.enums import ParseMode
 from modules.constants import PREFIXES
 from pyrogram.types import Message, CallbackQuery
 from pyrogram.handlers import MessageHandler, CallbackQueryHandler
@@ -14,7 +15,7 @@ async def approve_user(client: Client, message: Message):
     user_id = message.reply_to_message.from_user.id
     chat_id = message.chat.id
     await add_approval(chat_id, user_id)
-    await message.reply_text(f'✅ Approved [{user_id}](tg://user?id={user_id}).', parse_mode='markdown')
+    await message.reply_text(f'✅ Approved [{user_id}](tg://user?id={user_id}).', parse_mode=ParseMode.MARKDOWN)
 
 @admin_required
 async def unapprove_user(client: Client, message: Message):
@@ -24,7 +25,7 @@ async def unapprove_user(client: Client, message: Message):
     user_id = message.reply_to_message.from_user.id
     chat_id = message.chat.id
     await remove_approval(chat_id, user_id)
-    await message.reply_text(f'🚫 Unapproved [{user_id}](tg://user?id={user_id}).', parse_mode='markdown')
+    await message.reply_text(f'🚫 Unapproved [{user_id}](tg://user?id={user_id}).', parse_mode=ParseMode.MARKDOWN)
 
 @admin_required
 async def list_approved(client: Client, message: Message):
@@ -36,7 +37,7 @@ async def list_approved(client: Client, message: Message):
     text = '**✅ Approved Users:**\n'
     for user_id in users:
         text += f'- [User](tg://user?id={user_id}) (`{user_id}`)\n'
-    await message.reply_text(text, parse_mode='markdown')
+    await message.reply_text(text, parse_mode=ParseMode.MARKDOWN)
 
 @admin_required
 async def clear_approved(client: Client, message: Message):
@@ -48,14 +49,14 @@ async def clear_approved(client: Client, message: Message):
 async def approval_mode_cmd(client: Client, message: Message):
     if len(message.command) == 1:
         current = get_chat_setting(message.chat.id, 'approval_mode', 'off')
-        await message.reply_text(f'🔏 Approval mode is `{current}`.', parse_mode='markdown')
+        await message.reply_text(f'🔏 Approval mode is `{current}`.', parse_mode=ParseMode.MARKDOWN)
         return
     val = message.command[1].lower()
     if val not in {'on', 'off'}:
-        await message.reply_text('Usage: `/approvalmode <on/off>`', parse_mode='markdown')
+        await message.reply_text('Usage: `/approvalmode <on/off>`', parse_mode=ParseMode.MARKDOWN)
         return
     set_chat_setting(message.chat.id, 'approval_mode', val)
-    await message.reply_text(f'🔏 Approval mode set to `{val}`.', parse_mode='markdown')
+    await message.reply_text(f'🔏 Approval mode set to `{val}`.', parse_mode=ParseMode.MARKDOWN)
 
 async def approvals_cb(client: Client, query: CallbackQuery):
     data = query.data.split(':')[1]
@@ -67,7 +68,7 @@ async def approvals_cb(client: Client, query: CallbackQuery):
         text = 'Use /approved to list approved users.'
     else:
         text = 'Unknown command.'
-    await query.message.edit_text(text, reply_markup=approvals_panel(), parse_mode='markdown')
+    await query.message.edit_text(text, reply_markup=approvals_panel(), parse_mode=ParseMode.MARKDOWN)
     await query.answer()
 
 

--- a/plugins/blocklist.py
+++ b/plugins/blocklist.py
@@ -1,4 +1,5 @@
 from pyrogram import Client, filters
+from pyrogram.enums import ParseMode
 from modules.constants import PREFIXES
 from pyrogram.types import Message
 from pyrogram.handlers import MessageHandler
@@ -8,22 +9,22 @@ BLOCKLIST = {}
 @admin_required
 async def add_blocked_word(client: Client, message: Message):
     if len(message.command) < 2:
-        await message.reply_text('Usage: `/addblock <word>`', parse_mode='markdown')
+        await message.reply_text('Usage: `/addblock <word>`', parse_mode=ParseMode.MARKDOWN)
         return
     word = message.command[1].lower()
     chat_id = message.chat.id
     BLOCKLIST.setdefault(chat_id, set()).add(word)
-    await message.reply_text(f'🚫 Added `{word}` to blocklist.', parse_mode='markdown')
+    await message.reply_text(f'🚫 Added `{word}` to blocklist.', parse_mode=ParseMode.MARKDOWN)
 
 @admin_required
 async def remove_blocked_word(client: Client, message: Message):
     if len(message.command) < 2:
-        await message.reply_text('Usage: `/unblock <word>`', parse_mode='markdown')
+        await message.reply_text('Usage: `/unblock <word>`', parse_mode=ParseMode.MARKDOWN)
         return
     word = message.command[1].lower()
     chat_id = message.chat.id
     BLOCKLIST.setdefault(chat_id, set()).discard(word)
-    await message.reply_text(f'✅ Removed `{word}` from blocklist.', parse_mode='markdown')
+    await message.reply_text(f'✅ Removed `{word}` from blocklist.', parse_mode=ParseMode.MARKDOWN)
 
 @admin_required
 async def show_blocklist(client: Client, message: Message):
@@ -35,7 +36,7 @@ async def show_blocklist(client: Client, message: Message):
     text = '**🚫 Blocked Words:**\n'
     for word in sorted(words):
         text += f'• `{word}`\n'
-    await message.reply_text(text, parse_mode='markdown')
+    await message.reply_text(text, parse_mode=ParseMode.MARKDOWN)
 
 @admin_required
 async def clear_blocklist(client: Client, message: Message):

--- a/plugins/cleancommands.py
+++ b/plugins/cleancommands.py
@@ -1,4 +1,5 @@
 from pyrogram import Client, filters
+from pyrogram.enums import ParseMode
 from modules.constants import PREFIXES
 from pyrogram.types import Message
 from pyrogram.handlers import MessageHandler
@@ -9,7 +10,7 @@ import asyncio
 @admin_required
 async def set_clean(client: Client, message: Message):
     if len(message.command) < 2:
-        await message.reply_text('Usage: `/cleancommand <seconds|off>`', parse_mode='markdown')
+        await message.reply_text('Usage: `/cleancommand <seconds|off>`', parse_mode=ParseMode.MARKDOWN)
         return
     arg = message.command[1].lower()
     if arg in {'off', '0'}:
@@ -21,10 +22,10 @@ async def set_clean(client: Client, message: Message):
             if delay < 1:
                 raise ValueError
         except ValueError:
-            await message.reply_text('Please provide a number greater than 0 or use `off`.', parse_mode='markdown')
+            await message.reply_text('Please provide a number greater than 0 or use `off`.', parse_mode=ParseMode.MARKDOWN)
             return
         set_chat_setting(message.chat.id, 'clean_delay', str(delay))
-        await message.reply_text(f'🧼 Commands will be deleted after `{delay}` seconds.', parse_mode='markdown')
+        await message.reply_text(f'🧼 Commands will be deleted after `{delay}` seconds.', parse_mode=ParseMode.MARKDOWN)
 
 @admin_required
 async def keep_command(client: Client, message: Message):

--- a/plugins/connections.py
+++ b/plugins/connections.py
@@ -1,4 +1,5 @@
 from pyrogram import Client, filters
+from pyrogram.enums import ParseMode
 from modules.constants import PREFIXES
 from pyrogram.types import Message
 from pyrogram.handlers import MessageHandler
@@ -27,7 +28,7 @@ async def show_connection(client: Client, message: Message):
     if chat_id:
         try:
             chat = await client.get_chat(chat_id)
-            await message.reply_text(f'🔌 Currently connected to: `{chat.title}` (`{chat.id}`)', parse_mode='markdown')
+            await message.reply_text(f'🔌 Currently connected to: `{chat.title}` (`{chat.id}`)', parse_mode=ParseMode.MARKDOWN)
         except Exception:
             await message.reply_text('⚠️ Could not access connected group.')
     else:

--- a/plugins/disable.py
+++ b/plugins/disable.py
@@ -1,4 +1,5 @@
 from pyrogram import Client, filters, StopPropagation
+from pyrogram.enums import ParseMode
 from modules.constants import PREFIXES
 from pyrogram.types import Message
 from pyrogram.handlers import MessageHandler
@@ -25,22 +26,22 @@ DISABLED_CMDS = {}
 @admin_required
 async def disable_command(client: Client, message: Message):
     if len(message.command) < 2:
-        await message.reply_text('Usage: `/disable <command>`', parse_mode='markdown')
+        await message.reply_text('Usage: `/disable <command>`', parse_mode=ParseMode.MARKDOWN)
         return
     cmd = message.command[1].lower().lstrip('/')
     chat_id = message.chat.id
     DISABLED_CMDS.setdefault(chat_id, set()).add(cmd)
-    await message.reply_text(f'🚫 Command `/{cmd}` has been disabled.', parse_mode='markdown')
+    await message.reply_text(f'🚫 Command `/{cmd}` has been disabled.', parse_mode=ParseMode.MARKDOWN)
 
 @admin_required
 async def enable_command(client: Client, message: Message):
     if len(message.command) < 2:
-        await message.reply_text('Usage: `/enable <command>`', parse_mode='markdown')
+        await message.reply_text('Usage: `/enable <command>`', parse_mode=ParseMode.MARKDOWN)
         return
     cmd = message.command[1].lower().lstrip('/')
     chat_id = message.chat.id
     DISABLED_CMDS.setdefault(chat_id, set()).discard(cmd)
-    await message.reply_text(f'✅ Command `/{cmd}` has been enabled.', parse_mode='markdown')
+    await message.reply_text(f'✅ Command `/{cmd}` has been enabled.', parse_mode=ParseMode.MARKDOWN)
 
 @admin_required
 async def list_disabled(client: Client, message: Message):
@@ -51,7 +52,7 @@ async def list_disabled(client: Client, message: Message):
         return
     text = '**🚫 Disabled Commands:**\n'
     text += '\n'.join((f'• `/{cmd}`' for cmd in sorted(disabled)))
-    await message.reply_text(text, parse_mode='markdown')
+    await message.reply_text(text, parse_mode=ParseMode.MARKDOWN)
 
 async def block_disabled(client: Client, message: Message):
     chat_id = message.chat.id

--- a/plugins/federations.py
+++ b/plugins/federations.py
@@ -1,4 +1,5 @@
 from pyrogram import Client, filters
+from pyrogram.enums import ParseMode
 from modules.constants import PREFIXES
 from pyrogram.types import Message
 from pyrogram.handlers import MessageHandler
@@ -21,7 +22,7 @@ async def create_fed(client: Client, message: Message):
     FEDERATIONS[fed_name] = {'owner': user_id, 'banned_users': set()}
     USER_TO_FEDS.setdefault(user_id, set()).add(fed_name)
     safe = escape_markdown(fed_name)
-    await message.reply_text(f'✅ Federation `{safe}` has been created.', parse_mode='markdown')
+    await message.reply_text(f'✅ Federation `{safe}` has been created.', parse_mode=ParseMode.MARKDOWN)
 
 @admin_required
 async def join_fed(client: Client, message: Message):
@@ -34,7 +35,7 @@ async def join_fed(client: Client, message: Message):
         return
     GROUP_TO_FED[message.chat.id] = fed_name
     safe = escape_markdown(fed_name)
-    await message.reply_text(f'✅ This group has joined the `{safe}` federation.', parse_mode='markdown')
+    await message.reply_text(f'✅ This group has joined the `{safe}` federation.', parse_mode=ParseMode.MARKDOWN)
 
 @admin_required
 async def leave_fed(client: Client, message: Message):
@@ -43,7 +44,7 @@ async def leave_fed(client: Client, message: Message):
         return
     fed_name = GROUP_TO_FED.pop(message.chat.id)
     safe = escape_markdown(fed_name)
-    await message.reply_text(f'🚪 Group left the `{safe}` federation.', parse_mode='markdown')
+    await message.reply_text(f'🚪 Group left the `{safe}` federation.', parse_mode=ParseMode.MARKDOWN)
 
 async def list_feds(client: Client, message: Message):
     user_id = message.from_user.id
@@ -54,7 +55,7 @@ async def list_feds(client: Client, message: Message):
     text = '**📡 Your Federations:**\n'
     for fed in user_feds:
         text += f'• `{fed}`\n'
-    await message.reply_text(text, parse_mode='markdown')
+    await message.reply_text(text, parse_mode=ParseMode.MARKDOWN)
 
 @admin_required
 async def fed_ban(client: Client, message: Message):
@@ -69,7 +70,7 @@ async def fed_ban(client: Client, message: Message):
     user_id = message.reply_to_message.from_user.id
     FEDERATIONS[fed_name]['banned_users'].add(user_id)
     safe = escape_markdown(fed_name)
-    await message.reply_text(f'🚫 User `{user_id}` has been FedBanned in `{safe}`.', parse_mode='markdown')
+    await message.reply_text(f'🚫 User `{user_id}` has been FedBanned in `{safe}`.', parse_mode=ParseMode.MARKDOWN)
 
 @admin_required
 async def fed_unban(client: Client, message: Message):
@@ -84,7 +85,7 @@ async def fed_unban(client: Client, message: Message):
     user_id = message.reply_to_message.from_user.id
     FEDERATIONS[fed_name]['banned_users'].discard(user_id)
     safe = escape_markdown(fed_name)
-    await message.reply_text(f'✅ User `{user_id}` has been FedUnbanned in `{safe}`.', parse_mode='markdown')
+    await message.reply_text(f'✅ User `{user_id}` has been FedUnbanned in `{safe}`.', parse_mode=ParseMode.MARKDOWN)
 
 async def enforce_fedban(client: Client, message: Message):
     chat_id = message.chat.id

--- a/plugins/filters.py
+++ b/plugins/filters.py
@@ -1,4 +1,5 @@
 from pyrogram import Client, filters
+from pyrogram.enums import ParseMode
 from modules.constants import PREFIXES
 from pyrogram.types import Message, CallbackQuery
 from utils.markdown import escape_markdown
@@ -10,23 +11,23 @@ from utils.db import add_filter, remove_filter, list_filters, get_filter, clear_
 @is_admin
 async def add_filter_cmd(client: Client, message: Message):
     if len(message.command) < 3:
-        await message.reply_text('Usage: `/filter <word> <response>`', parse_mode='markdown')
+        await message.reply_text('Usage: `/filter <word> <response>`', parse_mode=ParseMode.MARKDOWN)
         return
     keyword = message.command[1].lower()
     response = ' '.join(message.command[2:])
     add_filter(message.chat.id, keyword, response)
     safe_key = escape_markdown(keyword)
-    await message.reply_text(f'✅ Filter `"{safe_key}"` added.', parse_mode='markdown')
+    await message.reply_text(f'✅ Filter `"{safe_key}"` added.', parse_mode=ParseMode.MARKDOWN)
 
 @is_admin
 async def stop_filter_cmd(client: Client, message: Message):
     if len(message.command) < 2:
-        await message.reply_text('Usage: `/stop <word>`', parse_mode='markdown')
+        await message.reply_text('Usage: `/stop <word>`', parse_mode=ParseMode.MARKDOWN)
         return
     keyword = message.command[1].lower()
     remove_filter(message.chat.id, keyword)
     safe_key = escape_markdown(keyword)
-    await message.reply_text(f'🗑️ Removed filter `"{safe_key}"`.', parse_mode='markdown')
+    await message.reply_text(f'🗑️ Removed filter `"{safe_key}"`.', parse_mode=ParseMode.MARKDOWN)
 
 async def list_filters_cmd(client: Client, message: Message):
     words = list_filters(message.chat.id)
@@ -34,7 +35,7 @@ async def list_filters_cmd(client: Client, message: Message):
         await message.reply_text('❌ No filters have been set in this chat.')
     else:
         text = '**📃 Active Filters:**\n' + '\n'.join((f'• `{w}`' for w in sorted(words)))
-        await message.reply_text(text, parse_mode='markdown')
+        await message.reply_text(text, parse_mode=ParseMode.MARKDOWN)
 
 @is_admin
 async def stopall_cmd(client: Client, message: Message):
@@ -62,7 +63,7 @@ async def filters_cb(client: Client, query: CallbackQuery):
         text = 'Use /filters to list all filters.'
     else:
         text = 'Unknown command.'
-    await query.message.edit_text(text, reply_markup=filters_panel(), parse_mode='markdown')
+    await query.message.edit_text(text, reply_markup=filters_panel(), parse_mode=ParseMode.MARKDOWN)
     await query.answer()
 
 

--- a/plugins/formatting.py
+++ b/plugins/formatting.py
@@ -1,4 +1,5 @@
 from pyrogram import Client, filters
+from pyrogram.enums import ParseMode
 from modules.constants import PREFIXES
 from pyrogram.types import Message, InlineKeyboardMarkup, InlineKeyboardButton
 from pyrogram.handlers import MessageHandler
@@ -6,7 +7,7 @@ from pyrogram.handlers import MessageHandler
 async def formatting_help(client: Client, message: Message):
     text = '\n**✨ Telegram Message Formatting Guide**\n\nYou can style your messages using Markdown or HTML formatting.\n\n**Markdown Examples:**\n• `*bold*` → *bold*\n• `_italic_` → _italic_\n• `` `code` `` → `code`\n• `[title](https://example.com)` → [title](https://example.com)\n\n**HTML Examples:**\n• `<b>bold</b>` → <b>bold</b>\n• `<i>italic</i>` → <i>italic</i>\n• `<a href="https://example.com">Link</a>` → <a href="https://example.com">Link</a>\n• `<code>code</code>` → <code>code</code>\n\n__Make sure bots are configured to parse Markdown or HTML!__\n'
     buttons = InlineKeyboardMarkup([[InlineKeyboardButton('📚 Telegram Formatting Docs', url='https://core.telegram.org/bots/api#formatting-options')]])
-    await message.reply_text(text, reply_markup=buttons, parse_mode='markdown')
+    await message.reply_text(text, reply_markup=buttons, parse_mode=ParseMode.MARKDOWN)
 
 
 def register(app):

--- a/plugins/greetings.py
+++ b/plugins/greetings.py
@@ -1,4 +1,5 @@
 from pyrogram import Client, filters
+from pyrogram.enums import ParseMode
 from modules.constants import PREFIXES
 from pyrogram.types import Message
 from pyrogram.handlers import MessageHandler
@@ -8,20 +9,20 @@ from utils.db import set_chat_setting, get_chat_setting
 @admin_required
 async def set_welcome(client: Client, message: Message):
     if len(message.command) < 2:
-        await message.reply_text('Usage: `/setwelcome <message>`', parse_mode='markdown')
+        await message.reply_text('Usage: `/setwelcome <message>`', parse_mode=ParseMode.MARKDOWN)
         return
     text = message.text.split(None, 1)[1]
     set_chat_setting(message.chat.id, 'welcome', text)
-    await message.reply_text('✅ Welcome message set.', parse_mode='markdown')
+    await message.reply_text('✅ Welcome message set.', parse_mode=ParseMode.MARKDOWN)
 
 @admin_required
 async def set_goodbye(client: Client, message: Message):
     if len(message.command) < 2:
-        await message.reply_text('Usage: `/setgoodbye <message>`', parse_mode='markdown')
+        await message.reply_text('Usage: `/setgoodbye <message>`', parse_mode=ParseMode.MARKDOWN)
         return
     text = message.text.split(None, 1)[1]
     set_chat_setting(message.chat.id, 'goodbye', text)
-    await message.reply_text('👋 Goodbye message set.', parse_mode='markdown')
+    await message.reply_text('👋 Goodbye message set.', parse_mode=ParseMode.MARKDOWN)
 
 async def show_greetings(client: Client, message: Message):
     welcome = get_chat_setting(message.chat.id, 'welcome', 'Not set.')
@@ -29,7 +30,7 @@ async def show_greetings(client: Client, message: Message):
     msg = '**👋 Greetings Settings:**\n'
     msg += f'• **Welcome:** `{welcome}`\n'
     msg += f'• **Goodbye:** `{goodbye}`'
-    await message.reply_text(msg, parse_mode='markdown')
+    await message.reply_text(msg, parse_mode=ParseMode.MARKDOWN)
 
 async def greet_new_members(client: Client, message: Message):
     text_template = get_chat_setting(message.chat.id, 'welcome')
@@ -37,7 +38,7 @@ async def greet_new_members(client: Client, message: Message):
         return
     for user in message.new_chat_members:
         text = format_greeting(text_template, user, message.chat.title)
-        await message.reply_text(text, parse_mode='markdown')
+        await message.reply_text(text, parse_mode=ParseMode.MARKDOWN)
 
 async def farewell_user(client: Client, message: Message):
     text_template = get_chat_setting(message.chat.id, 'goodbye')
@@ -45,7 +46,7 @@ async def farewell_user(client: Client, message: Message):
         return
     user = message.left_chat_member
     text = format_greeting(text_template, user, message.chat.title)
-    await message.reply_text(text, parse_mode='markdown')
+    await message.reply_text(text, parse_mode=ParseMode.MARKDOWN)
 
 def format_greeting(template: str, user, chat_title: str) -> str:
     first = user.first_name or ''

--- a/plugins/help.py
+++ b/plugins/help.py
@@ -2,6 +2,7 @@
 
 import logging
 from pyrogram import filters
+from pyrogram.enums import ParseMode
 from pyrogram.handlers import MessageHandler
 from utils.errors import catch_errors
 from modules.constants import PREFIXES
@@ -36,7 +37,7 @@ async def help_cmd(client, message):
     LOGGER.debug("📩 /help command handled by help.py")
     text = "**Available Modules:**\n\n"
     text += "\n".join([f"- `{mod}`: {desc}" for mod, desc in HELP_MODULES.items()])
-    await message.reply_text(text, parse_mode="markdown")
+    await message.reply_text(text, parse_mode=ParseMode.MARKDOWN)
 
 def register(app) -> None:
     """Register a simple /help handler to ensure help works even if start.py fails."""

--- a/plugins/importexport.py
+++ b/plugins/importexport.py
@@ -1,5 +1,6 @@
 import json
 from pyrogram import Client, filters
+from pyrogram.enums import ParseMode
 from modules.constants import PREFIXES
 from pyrogram.types import Message, Document
 from pyrogram.handlers import MessageHandler
@@ -26,14 +27,14 @@ async def import_data(client: Client, message: Message):
         with open(file_path, 'r', encoding='utf-8') as f:
             data = json.load(f)
     except Exception as e:
-        await message.reply(f'❌ Failed to parse JSON file:\n`{e}`', parse_mode='markdown')
+        await message.reply(f'❌ Failed to parse JSON file:\n`{e}`', parse_mode=ParseMode.MARKDOWN)
         return
     count = await import_chat_data(message.chat.id, data)
-    await message.reply(f'✅ Imported `{count}` items successfully.', parse_mode='markdown')
+    await message.reply(f'✅ Imported `{count}` items successfully.', parse_mode=ParseMode.MARKDOWN)
 
 async def importexport_help(client: Client, message: Message):
     text = '**📤 Import & Export Help**\n\n`/export` - Get current group settings as `.json`\n`/import` - Reply to a `.json` file to restore settings\n\n_Only group admins can use this. Useful for backups and moving data._'
-    await message.reply_text(text, parse_mode='markdown')
+    await message.reply_text(text, parse_mode=ParseMode.MARKDOWN)
 
 
 def register(app):

--- a/plugins/languages.py
+++ b/plugins/languages.py
@@ -1,4 +1,5 @@
 from pyrogram import Client, filters
+from pyrogram.enums import ParseMode
 from modules.constants import PREFIXES
 from pyrogram.types import Message
 from pyrogram.handlers import MessageHandler
@@ -9,19 +10,19 @@ SUPPORTED_LANGUAGES = {'en': 'English 🇬🇧', 'hi': 'Hindi 🇮🇳', 'es': '
 async def show_languages(client: Client, message: Message):
     current = get_chat_setting(message.chat.id, 'lang', 'en')
     langs = '\n'.join((f'• `{code}` - {name}' for code, name in SUPPORTED_LANGUAGES.items()))
-    await message.reply_text(f'**🌐 Current Language:** `{current}`\n\n**Available Languages:**\n{langs}\n\nTo change: `/setlang <code>`', parse_mode='markdown')
+    await message.reply_text(f'**🌐 Current Language:** `{current}`\n\n**Available Languages:**\n{langs}\n\nTo change: `/setlang <code>`', parse_mode=ParseMode.MARKDOWN)
 
 @admin_required
 async def set_language(client: Client, message: Message):
     if len(message.command) < 2:
-        await message.reply_text('Usage: `/setlang <language_code>`', parse_mode='markdown')
+        await message.reply_text('Usage: `/setlang <language_code>`', parse_mode=ParseMode.MARKDOWN)
         return
     code = message.command[1].lower()
     if code not in SUPPORTED_LANGUAGES:
         await message.reply_text('❌ Invalid language code. Use `/languages` to see available options.')
         return
     set_chat_setting(message.chat.id, 'lang', code)
-    await message.reply_text(f'✅ Language set to `{SUPPORTED_LANGUAGES[code]}`', parse_mode='markdown')
+    await message.reply_text(f'✅ Language set to `{SUPPORTED_LANGUAGES[code]}`', parse_mode=ParseMode.MARKDOWN)
 
 
 def register(app):

--- a/plugins/locks.py
+++ b/plugins/locks.py
@@ -1,4 +1,5 @@
 from pyrogram import Client, filters, types
+from pyrogram.enums import ParseMode
 from modules.constants import PREFIXES
 from pyrogram.handlers import MessageHandler, CallbackQueryHandler
 from utils.decorators import admin_required
@@ -16,7 +17,7 @@ def build_permissions(**kwargs):
 @admin_required
 async def lock_cmd(client: Client, message: types.Message):
     if len(message.command) < 2:
-        await message.reply_text('Usage: `/lock <type>`', parse_mode='markdown')
+        await message.reply_text('Usage: `/lock <type>`', parse_mode=ParseMode.MARKDOWN)
         return
     lock_type = message.command[1].lower()
     if lock_type == 'messages':
@@ -30,12 +31,12 @@ async def lock_cmd(client: Client, message: types.Message):
         return
     perms = build_permissions(**{perm: False})
     await client.set_chat_permissions(message.chat.id, perms)
-    await message.reply_text(f'🔒 Locked `{lock_type}`.', parse_mode='markdown')
+    await message.reply_text(f'🔒 Locked `{lock_type}`.', parse_mode=ParseMode.MARKDOWN)
 
 @admin_required
 async def unlock_cmd(client: Client, message: types.Message):
     if len(message.command) < 2:
-        await message.reply_text('Usage: `/unlock <type>`', parse_mode='markdown')
+        await message.reply_text('Usage: `/unlock <type>`', parse_mode=ParseMode.MARKDOWN)
         return
     lock_type = message.command[1].lower()
     if lock_type == 'messages':
@@ -49,7 +50,7 @@ async def unlock_cmd(client: Client, message: types.Message):
         return
     perms = build_permissions(**{perm: True})
     await client.set_chat_permissions(message.chat.id, perms)
-    await message.reply_text(f'🔓 Unlocked `{lock_type}`.', parse_mode='markdown')
+    await message.reply_text(f'🔓 Unlocked `{lock_type}`.', parse_mode=ParseMode.MARKDOWN)
 
 async def lock_cb(client: Client, query: CallbackQuery):
     data = query.data.split(':')[1]
@@ -59,7 +60,7 @@ async def lock_cb(client: Client, query: CallbackQuery):
         text = 'Use /unlock <type> to unlock.'
     else:
         text = 'Unknown command.'
-    await query.message.edit_text(text, reply_markup=lock_panel(), parse_mode='markdown')
+    await query.message.edit_text(text, reply_markup=lock_panel(), parse_mode=ParseMode.MARKDOWN)
     await query.answer()
 
 

--- a/plugins/logchannel.py
+++ b/plugins/logchannel.py
@@ -1,4 +1,5 @@
 from pyrogram import Client, filters
+from pyrogram.enums import ParseMode
 from modules.constants import PREFIXES
 from pyrogram.types import Message
 from pyrogram.handlers import MessageHandler
@@ -12,7 +13,7 @@ async def logchannel_handler(client: Client, message: Message):
         log_id = get_chat_setting(message.chat.id, 'log_channel')
         if log_id:
             safe_id = escape_markdown(str(log_id))
-            await message.reply_text(f'📝 Log channel is set to: `{safe_id}`', parse_mode='markdown')
+            await message.reply_text(f'📝 Log channel is set to: `{safe_id}`', parse_mode=ParseMode.MARKDOWN)
         else:
             await message.reply_text('ℹ️ No log channel set.')
         return
@@ -36,17 +37,17 @@ async def logchannel_handler(client: Client, message: Message):
             return
         set_chat_setting(message.chat.id, 'log_channel', chat.id)
         safe_title = escape_markdown(chat.title)
-        await message.reply_text(f'✅ Logs will be sent to: `{safe_title}` (`{chat.id}`)', parse_mode='markdown')
+        await message.reply_text(f'✅ Logs will be sent to: `{safe_title}` (`{chat.id}`)', parse_mode=ParseMode.MARKDOWN)
     except Exception as e:
         safe_err = escape_markdown(str(e))
-        await message.reply_text(f'❌ Failed to set log channel:\n`{safe_err}`', parse_mode='markdown')
+        await message.reply_text(f'❌ Failed to set log channel:\n`{safe_err}`', parse_mode=ParseMode.MARKDOWN)
 
 async def send_log(client: Client, chat_id: int, text: str):
     log_id = get_chat_setting(chat_id, 'log_channel')
     if not log_id:
         return
     try:
-        await client.send_message(log_id, text, parse_mode='markdown')
+        await client.send_message(log_id, text, parse_mode=ParseMode.MARKDOWN)
     except Exception:
         pass
 

--- a/plugins/misc.py
+++ b/plugins/misc.py
@@ -1,5 +1,6 @@
 import random
 from pyrogram import Client, filters
+from pyrogram.enums import ParseMode
 from modules.constants import PREFIXES
 from pyrogram.handlers import MessageHandler
 from pyrogram.types import Message
@@ -13,7 +14,7 @@ async def get_id(client: Client, message: Message):
         target = message.reply_to_message.from_user
     else:
         target = message.from_user
-    await message.reply_text(f'🆔 ID: `{target.id}`', parse_mode='markdown')
+    await message.reply_text(f'🆔 ID: `{target.id}`', parse_mode=ParseMode.MARKDOWN)
 
 async def info(client: Client, message: Message):
     user = message.reply_to_message.from_user if message.reply_to_message else message.from_user
@@ -22,15 +23,15 @@ async def info(client: Client, message: Message):
         text += f'\nUsername: @{user.username}'
     if user.bio:
         text += f'\nBio: {user.bio}'
-    await message.reply_text(text, parse_mode='markdown')
+    await message.reply_text(text, parse_mode=ParseMode.MARKDOWN)
 
 async def donate(client: Client, message: Message):
-    await message.reply_text("[❤️ Donate here](https://example.com/donate) to support the bot's development!", disable_web_page_preview=True, parse_mode='markdown')
+    await message.reply_text("[❤️ Donate here](https://example.com/donate) to support the bot's development!", disable_web_page_preview=True, parse_mode=ParseMode.MARKDOWN)
 
 async def markdown_help(client: Client, message: Message):
     if message.chat.type != 'private':
         await message.reply('📬 I’ve sent you the Markdown guide in private.')
-    await client.send_message(message.from_user.id, '**✏️ Markdown Guide**\nUse:\n- `*bold*`\n- `_italic_`\n- `[text](url)`', parse_mode='markdown')
+    await client.send_message(message.from_user.id, '**✏️ Markdown Guide**\nUse:\n- `*bold*`\n- `_italic_`\n- `[text](url)`', parse_mode=ParseMode.MARKDOWN)
 
 async def limits(client: Client, message: Message):
     await message.reply_text('🚫 No limits are currently enforced.')

--- a/plugins/misc2.py
+++ b/plugins/misc2.py
@@ -1,4 +1,5 @@
 from pyrogram import Client, filters
+from pyrogram.enums import ParseMode
 from modules.constants import PREFIXES
 from pyrogram.handlers import MessageHandler
 from pyrogram.types import Message
@@ -9,7 +10,7 @@ async def ping(client: Client, message: Message):
     if message.chat.type == 'private':
         reply = await message.reply_text('Pong!')
         end = time.monotonic()
-        await reply.edit_text(f'Pong! `{(end - start) * 1000:.0f}ms`', parse_mode='markdown')
+        await reply.edit_text(f'Pong! `{(end - start) * 1000:.0f}ms`', parse_mode=ParseMode.MARKDOWN)
     else:
         await message.reply("📩 Pong sent in PM.")
         end = time.monotonic()
@@ -17,14 +18,14 @@ async def ping(client: Client, message: Message):
             await client.send_message(
                 message.from_user.id,
                 f'Pong! `{(end - start) * 1000:.0f}ms`',
-                parse_mode='markdown',
+                parse_mode=ParseMode.MARKDOWN,
             )
         except Exception:
             await message.reply("❌ I can't message you. Please start me in PM first.")
 
 async def echo(client: Client, message: Message):
     if len(message.command) < 2:
-        await message.reply_text('Usage: `/echo <text>`', parse_mode='markdown')
+        await message.reply_text('Usage: `/echo <text>`', parse_mode=ParseMode.MARKDOWN)
         return
     await message.reply_text(' '.join(message.command[1:]))
 

--- a/plugins/notes.py
+++ b/plugins/notes.py
@@ -1,4 +1,5 @@
 from pyrogram import Client, filters
+from pyrogram.enums import ParseMode
 from modules.constants import PREFIXES
 from pyrogram.handlers import MessageHandler, CallbackQueryHandler
 from pyrogram.types import Message, CallbackQuery, InlineKeyboardMarkup, InlineKeyboardButton
@@ -18,7 +19,7 @@ def _get_note(chat_id: int, name: str):
 @admin_required
 async def save_note(client: Client, message: Message):
     if len(message.command) < 2:
-        await message.reply('Usage: `/save <name>` (reply or give text)', parse_mode='markdown')
+        await message.reply('Usage: `/save <name>` (reply or give text)', parse_mode=ParseMode.MARKDOWN)
         return
     name = message.command[1].lower()
     if message.reply_to_message:
@@ -36,7 +37,7 @@ async def save_note(client: Client, message: Message):
 @admin_required
 async def clear_note(client: Client, message: Message):
     if len(message.command) < 2:
-        await message.reply('Usage: `/clear <name>`', parse_mode='markdown')
+        await message.reply('Usage: `/clear <name>`', parse_mode=ParseMode.MARKDOWN)
         return
     name = message.command[1].lower()
     cur = conn.cursor()
@@ -52,7 +53,7 @@ async def list_notes(client: Client, message: Message):
         await message.reply('❌ No notes found in this chat.')
     else:
         text = '**📝 Saved Notes:**\n' + '\n'.join((f'• `{n[0]}`' for n in rows))
-        await message.reply(text, reply_markup=notes_panel(), parse_mode='markdown')
+        await message.reply(text, reply_markup=notes_panel(), parse_mode=ParseMode.MARKDOWN)
 
 @admin_required
 async def clear_all_notes(client: Client, message: Message):
@@ -66,11 +67,11 @@ async def private_notes_toggle(client: Client, message: Message):
     current = get_chat_setting(message.chat.id, 'privatenotes', 'off')
     new = 'off' if current == 'on' else 'on'
     set_chat_setting(message.chat.id, 'privatenotes', new)
-    await message.reply(f'🔒 Private notes are now `{new}`.', parse_mode='markdown')
+    await message.reply(f'🔒 Private notes are now `{new}`.', parse_mode=ParseMode.MARKDOWN)
 
 async def get_note_cmd(client: Client, message: Message):
     if len(message.command) < 2:
-        await message.reply('Usage: `/get <name>`', parse_mode='markdown')
+        await message.reply('Usage: `/get <name>`', parse_mode=ParseMode.MARKDOWN)
         return
     name = message.command[1].lower()
     content = _get_note(message.chat.id, name)
@@ -97,9 +98,9 @@ async def get_note_hash(client: Client, message: Message):
 async def notes_cb(client: Client, query: CallbackQuery):
     data = query.data.split(':')[1]
     if data == 'example':
-        await query.message.edit_text('📌 To save a note:\nReply to a message and use `/save keyword`\nOr `/save keyword content`.', reply_markup=notes_panel(), parse_mode='markdown')
+        await query.message.edit_text('📌 To save a note:\nReply to a message and use `/save keyword`\nOr `/save keyword content`.', reply_markup=notes_panel(), parse_mode=ParseMode.MARKDOWN)
     elif data == 'format':
-        await query.message.edit_text('**📎 Formatting Guide**\n- Markdown supported\n- Buttons via `[text](url)` allowed.', reply_markup=notes_panel(), parse_mode='markdown')
+        await query.message.edit_text('**📎 Formatting Guide**\n- Markdown supported\n- Buttons via `[text](url)` allowed.', reply_markup=notes_panel(), parse_mode=ParseMode.MARKDOWN)
     await query.answer()
 
 

--- a/plugins/pin.py
+++ b/plugins/pin.py
@@ -1,4 +1,5 @@
 from pyrogram import Client, filters
+from pyrogram.enums import ParseMode
 from modules.constants import PREFIXES
 from pyrogram.handlers import MessageHandler
 from utils.decorators import admin_required
@@ -11,7 +12,7 @@ async def pinned_cmd(client: Client, message):
         await message.reply('📌 No message is pinned currently.')
     else:
         content = chat.pinned_message.text or chat.pinned_message.caption or '📎 [Media message]'
-        await message.reply(f'📌 **Pinned Message:**\n\n{content}', parse_mode='markdown')
+        await message.reply(f'📌 **Pinned Message:**\n\n{content}', parse_mode=ParseMode.MARKDOWN)
 
 @admin_required
 async def pin_cmd(client: Client, message):
@@ -27,7 +28,7 @@ async def pin_cmd(client: Client, message):
 @admin_required
 async def permapin_cmd(client: Client, message):
     if len(message.command) < 2:
-        await message.reply('Usage: `/permapin <text>`', parse_mode='markdown')
+        await message.reply('Usage: `/permapin <text>`', parse_mode=ParseMode.MARKDOWN)
         return
     text = ' '.join(message.command[1:])
     sent = await message.reply(text)
@@ -53,30 +54,30 @@ async def antichannelpin_cmd(client: Client, message):
     if len(message.command) == 1:
         state = get_chat_setting(message.chat.id, 'antichannelpin', 'off')
         safe_state = escape_markdown(state)
-        await message.reply(f'📡 Anti-channel pin is currently `{safe_state}`.', parse_mode='markdown')
+        await message.reply(f'📡 Anti-channel pin is currently `{safe_state}`.', parse_mode=ParseMode.MARKDOWN)
         return
     value = message.command[1].lower()
     if value not in {'on', 'off'}:
-        await message.reply('Usage: `/antichannelpin <on/off>`', parse_mode='markdown')
+        await message.reply('Usage: `/antichannelpin <on/off>`', parse_mode=ParseMode.MARKDOWN)
         return
     set_chat_setting(message.chat.id, 'antichannelpin', value)
     safe_val = escape_markdown(value)
-    await message.reply(f'📡 Anti-channel pin set to `{safe_val}`.', parse_mode='markdown')
+    await message.reply(f'📡 Anti-channel pin set to `{safe_val}`.', parse_mode=ParseMode.MARKDOWN)
 
 @admin_required
 async def cleanlinked_cmd(client: Client, message):
     if len(message.command) == 1:
         state = get_chat_setting(message.chat.id, 'cleanlinked', 'off')
         safe_state = escape_markdown(state)
-        await message.reply(f'🧼 Clean linked messages is `{safe_state}`.', parse_mode='markdown')
+        await message.reply(f'🧼 Clean linked messages is `{safe_state}`.', parse_mode=ParseMode.MARKDOWN)
         return
     value = message.command[1].lower()
     if value not in {'on', 'off'}:
-        await message.reply('Usage: `/cleanlinked <on/off>`', parse_mode='markdown')
+        await message.reply('Usage: `/cleanlinked <on/off>`', parse_mode=ParseMode.MARKDOWN)
         return
     set_chat_setting(message.chat.id, 'cleanlinked', value)
     safe_val = escape_markdown(value)
-    await message.reply(f'🧼 Clean linked messages set to `{safe_val}`.', parse_mode='markdown')
+    await message.reply(f'🧼 Clean linked messages set to `{safe_val}`.', parse_mode=ParseMode.MARKDOWN)
 
 
 def register(app):

--- a/plugins/privacy.py
+++ b/plugins/privacy.py
@@ -1,4 +1,5 @@
 from pyrogram import Client, filters
+from pyrogram.enums import ParseMode
 from modules.constants import PREFIXES
 from pyrogram.handlers import MessageHandler
 
@@ -7,11 +8,11 @@ async def privacy_cmd(client: Client, message):
     if message.chat.type != 'private':
         await message.reply("📩 I've sent you my privacy policy in PM.")
         try:
-            await client.send_message(message.from_user.id, text, parse_mode='markdown')
+            await client.send_message(message.from_user.id, text, parse_mode=ParseMode.MARKDOWN)
         except Exception:
             await message.reply("❌ I can't message you. Please start me in PM first.")
     else:
-        await message.reply(text, parse_mode='markdown')
+        await message.reply(text, parse_mode=ParseMode.MARKDOWN)
 
 async def del_my_data(client: Client, message):
     await message.reply('🗑️ Your data has been deleted from our systems (mock response).')

--- a/plugins/purge.py
+++ b/plugins/purge.py
@@ -1,4 +1,5 @@
 from pyrogram import Client, filters
+from pyrogram.enums import ParseMode
 from modules.constants import PREFIXES
 from pyrogram.handlers import MessageHandler
 from utils.decorators import admin_required
@@ -17,7 +18,7 @@ async def purge_cmd(client: Client, message):
     ids = list(range(start_id, start_id + limit + 1)) if limit else list(range(start_id, end_id + 1))
     try:
         await client.delete_messages(message.chat.id, ids)
-        await message.reply(f'🧹 Deleted `{len(ids)}` messages.', quote=False, parse_mode='markdown')
+        await message.reply(f'🧹 Deleted `{len(ids)}` messages.', quote=False, parse_mode=ParseMode.MARKDOWN)
     except Exception:
         await message.reply('⚠️ Failed to purge messages.')
 
@@ -51,12 +52,12 @@ async def purge_from_cmd(client: Client, message):
 async def purge_to_cmd(client: Client, message):
     start = purge_points.get(message.chat.id)
     if not start:
-        await message.reply('⚠️ No purge point set. Use `/purgefrom` first.', parse_mode='markdown')
+        await message.reply('⚠️ No purge point set. Use `/purgefrom` first.', parse_mode=ParseMode.MARKDOWN)
         return
     ids = list(range(start, message.id + 1))
     try:
         await client.delete_messages(message.chat.id, ids)
-        await message.reply(f'🧹 Deleted `{len(ids)}` messages.', quote=False, parse_mode='markdown')
+        await message.reply(f'🧹 Deleted `{len(ids)}` messages.', quote=False, parse_mode=ParseMode.MARKDOWN)
     except Exception:
         await message.reply('⚠️ Failed to purge messages.')
     purge_points.pop(message.chat.id, None)

--- a/plugins/reports.py
+++ b/plugins/reports.py
@@ -1,5 +1,6 @@
 import logging
 from pyrogram import Client, filters
+from pyrogram.enums import ParseMode
 from modules.constants import PREFIXES
 from pyrogram.types import Message
 from pyrogram.handlers import MessageHandler
@@ -43,7 +44,7 @@ async def handle_report(client: Client, message: Message):
     try:
         await message.reply(
             report_text,
-            parse_mode="markdown",
+            parse_mode=ParseMode.MARKDOWN,
             disable_web_page_preview=True,
         )
     except RPCError as e:

--- a/plugins/rules.py
+++ b/plugins/rules.py
@@ -1,5 +1,6 @@
 import logging
 from pyrogram import Client, filters
+from pyrogram.enums import ParseMode
 from modules.constants import PREFIXES
 from pyrogram.handlers import MessageHandler, CallbackQueryHandler
 from utils.decorators import admin_required
@@ -38,7 +39,7 @@ async def rules_cmd(client, message):
 @admin_required
 async def setrules_cmd(client, message):
     if len(message.command) < 2 and (not message.reply_to_message):
-        await message.reply('📝 Usage: `/setrules <text>` or reply to a message', parse_mode='markdown')
+        await message.reply('📝 Usage: `/setrules <text>` or reply to a message', parse_mode=ParseMode.MARKDOWN)
         return
     text = message.reply_to_message.text if message.reply_to_message else ' '.join(message.command[1:])
     set_chat_setting(message.chat.id, 'rules_text', text)
@@ -85,7 +86,7 @@ async def rules_cb(client: Client, query: CallbackQuery):
         text = 'Use /setrulesbutton to set the rules button label.'
     else:
         text = 'Unknown command.'
-    await query.message.edit_text(text, reply_markup=rules_panel(), parse_mode='markdown')
+    await query.message.edit_text(text, reply_markup=rules_panel(), parse_mode=ParseMode.MARKDOWN)
     await query.answer()
 
 def register(app):

--- a/plugins/start.py
+++ b/plugins/start.py
@@ -1,5 +1,6 @@
 import logging
 from pyrogram import Client, filters
+from pyrogram.enums import ParseMode
 from pyrogram.types import (
     CallbackQuery,
     InlineKeyboardButton,
@@ -102,7 +103,7 @@ async def start_cmd(client: Client, message: Message):
                 [[InlineKeyboardButton('📋 Menu', callback_data='menu:open')]]
             ),
             quote=True,
-            parse_mode="markdown",
+            parse_mode=ParseMode.MARKDOWN,
         )
     else:
         await message.reply("📩 I've sent you a PM with information.")
@@ -114,7 +115,7 @@ async def start_cmd(client: Client, message: Message):
                     reply_markup=InlineKeyboardMarkup(
                         [[InlineKeyboardButton('📋 Menu', callback_data='menu:open')]]
                     ),
-                    parse_mode="markdown",
+                    parse_mode=ParseMode.MARKDOWN,
                 )
             except Exception as e:
                 LOGGER.warning("Cannot PM user: %s", e)
@@ -128,7 +129,7 @@ async def menu_cmd(client: Client, message: Message):
         "**📋 Control Panel**",
         reply_markup=build_menu(),
         quote=True,
-        parse_mode="markdown",
+        parse_mode=ParseMode.MARKDOWN,
     )
 
 
@@ -148,7 +149,7 @@ async def help_cmd(client: Client, message: Message):
     from_user_id = getattr(message.from_user, "id", None)
 
     if chat_type == 'private':
-        await message.reply_text(response, reply_markup=help_menu(), parse_mode="markdown")
+        await message.reply_text(response, reply_markup=help_menu(), parse_mode=ParseMode.MARKDOWN)
     else:
         await message.reply("📩 I've sent you a PM with help information.")
         if from_user_id:
@@ -157,7 +158,7 @@ async def help_cmd(client: Client, message: Message):
                     from_user_id,
                     response,
                     reply_markup=help_menu(),
-                    parse_mode="markdown",
+                    parse_mode=ParseMode.MARKDOWN,
                 )
             except Exception as e:
                 LOGGER.warning("Cannot PM user: %s", e)
@@ -189,7 +190,7 @@ async def menu_open_cb(client: Client, query: CallbackQuery):
     await query.message.edit_text(
         "**📋 Control Panel**",
         reply_markup=build_menu(),
-        parse_mode="markdown",
+        parse_mode=ParseMode.MARKDOWN,
     )
     await query.answer()
 
@@ -204,7 +205,7 @@ async def panel_open_cb(client: Client, query: CallbackQuery):
     await query.message.edit_text(
         f"**🔧 {module.title()} Panel**",
         reply_markup=markup,
-        parse_mode="markdown",
+        parse_mode=ParseMode.MARKDOWN,
     )
     await query.answer()
 
@@ -214,7 +215,7 @@ async def menu_cb(client: Client, query: CallbackQuery):
     await query.message.edit_text(
         "**📋 Control Panel**",
         reply_markup=build_menu(),
-        parse_mode="markdown",
+        parse_mode=ParseMode.MARKDOWN,
     )
     await query.answer()
 
@@ -238,7 +239,7 @@ async def help_cb(client: Client, query: CallbackQuery):
         await query.message.delete()
         return
     text = HELP_MODULES.get(mod, "❌ Module not found.")
-    await query.message.edit_text(text, reply_markup=help_menu(), parse_mode="markdown")
+    await query.message.edit_text(text, reply_markup=help_menu(), parse_mode=ParseMode.MARKDOWN)
     await query.answer()
 
 

--- a/plugins/warnings.py
+++ b/plugins/warnings.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 from pyrogram import Client, filters, types
+from pyrogram.enums import ParseMode
 from modules.constants import PREFIXES
 from pyrogram.handlers import MessageHandler, CallbackQueryHandler
 from utils.decorators import is_admin
@@ -165,7 +166,7 @@ async def warnings_cb(client: Client, query: CallbackQuery):
         text = 'Use /warnings to view current settings.'
     else:
         text = 'Unknown command.'
-    await query.message.edit_text(text, reply_markup=warnings_panel(), parse_mode='markdown')
+    await query.message.edit_text(text, reply_markup=warnings_panel(), parse_mode=ParseMode.MARKDOWN)
     await query.answer()
 
 


### PR DESCRIPTION
## Summary
- fix incorrect parse_mode strings causing runtime errors
- use ParseMode.MARKDOWN constant throughout

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6887b3c3517c8329ae20bc39e0eb1177